### PR TITLE
[converter] handle default methods - FELIX-6239

### DIFF
--- a/converter/converter/src/test/java/org/osgi/util/converter/ConverterTest.java
+++ b/converter/converter/src/test/java/org/osgi/util/converter/ConverterTest.java
@@ -1465,6 +1465,14 @@ public class ConverterTest {
         assertNotNull(k);
     }
 
+    @Test
+    public void testDefaultInterfaceMethod() throws Throwable
+    {
+        Class<?> clazz = InterfaceWithDefaultMethod.class;
+        InterfaceWithDefaultMethod i = (InterfaceWithDefaultMethod) Converters.standardConverter().convert(
+            new HashMap<String, Object>()).to(clazz);
+        assertEquals(InterfaceWithDefaultMethod.RESULT, i.defaultMethod());
+    }
     static interface MyIntf2 {
         String code();
         Integer value();

--- a/converter/converter/src/test/java/org/osgi/util/converter/InterfaceWithDefaultMethod.java
+++ b/converter/converter/src/test/java/org/osgi/util/converter/InterfaceWithDefaultMethod.java
@@ -1,0 +1,11 @@
+package org.osgi.util.converter;
+
+public interface InterfaceWithDefaultMethod
+{
+    public static final String RESULT = "r";
+
+    public default String defaultMethod()
+    {
+        return RESULT;
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FELIX-6239

Default methods in interfaces exist since Java 8.
I did not found ONE way to invoke them.
I check the Java-Version and handles 2 different ways.

Maybe i should add an try-catch block do handle exceptions?