### PR TITLE
[FELIX-6246] Packaged External Library Packages inside referenced Health Check Bundles

### DIFF
--- a/healthcheck/api/bnd.bnd
+++ b/healthcheck/api/bnd.bnd
@@ -1,12 +1,6 @@
-Bundle-Category: healthcheck
-
-Bundle-Description: ${project.description}
-
-Bundle-DocURL: https://felix.apache.org
-
-Bundle-License: Apache License, Version 2.0
-
-Bundle-Vendor: The Apache Software Foundation
-
-Export-Package: org.apache.felix.hc.api.*
-
+Bundle-Category     : healthcheck
+Bundle-Description  : ${project.description}
+Bundle-DocURL       : https://felix.apache.org
+Bundle-License      : Apache License, Version 2.0
+Bundle-Vendor       : The Apache Software Foundation
+Export-Package      : org.apache.felix.hc.api.*

--- a/healthcheck/core/bnd.bnd
+++ b/healthcheck/core/bnd.bnd
@@ -1,17 +1,8 @@
-Bundle-Category: healthcheck
-
-Bundle-Description: ${project.description}
-
-Bundle-DocURL: https://felix.apache.org
-
-Bundle-License: Apache License, Version 2.0
-
-Bundle-Vendor: The Apache Software Foundation
-
-Import-Package: org.quartz*;resolution:="optional", *
-
-Conditional-Package: org.apache.felix.utils.*
-
--removeheaders:\
-  Include-Resource,\
-  Private-Package
+Bundle-Category       : healthcheck
+Bundle-Description    : ${project.description}
+Bundle-DocURL         : https://felix.apache.org
+Bundle-License        : Apache License, Version 2.0
+Bundle-Vendor         : The Apache Software Foundation
+Import-Package        : org.quartz*;resolution:="optional", *
+-conditionalpackage   : org.apache.felix.utils.*, org.apache.commons.lang3.*
+-removeheaders        : Include-Resource, Private-Package

--- a/healthcheck/generalchecks/bnd.bnd
+++ b/healthcheck/generalchecks/bnd.bnd
@@ -1,15 +1,11 @@
-Bundle-Category: healthcheck
-
-Bundle-Description: ${project.description}
-
-Bundle-DocURL: https://felix.apache.org
-
-Bundle-License: Apache License, Version 2.0
-
-Bundle-Vendor: The Apache Software Foundation
-
-Conditional-Package: org.apache.commons.cli.*,org.apache.felix.utils.*
-
-Export-Package: org.apache.felix.hc.generalchecks.util
-
-Import-Package: org.apache.felix.rootcause*;resolution:="optional", *
+Bundle-Category     : healthcheck
+Bundle-Description  : ${project.description}
+Bundle-DocURL       : https://felix.apache.org
+Bundle-License      : Apache License, Version 2.0
+Bundle-Vendor       : The Apache Software Foundation
+Export-Package      : org.apache.felix.hc.generalchecks.util
+Import-Package      : org.apache.felix.rootcause*;resolution:="optional", *
+-conditionalpackage : \
+	org.apache.felix.utils.*,\
+	org.apache.commons.cli.*,\
+	org.apache.commons.lang3.*

--- a/healthcheck/webconsoleplugin/bnd.bnd
+++ b/healthcheck/webconsoleplugin/bnd.bnd
@@ -1,10 +1,6 @@
-Bundle-Category: healthcheck
-
-Bundle-Description: ${project.description}
-
-Bundle-DocURL: https://felix.apache.org
-
-Bundle-License: Apache License, Version 2.0
-
-Bundle-Vendor: The Apache Software Foundation
-
+Bundle-Category      : healthcheck
+Bundle-Description   : ${project.description}
+Bundle-DocURL        : https://felix.apache.org
+Bundle-License       : Apache License, Version 2.0
+Bundle-Vendor        : The Apache Software Foundation
+-conditionalpackage  : org.apache.commons.lang3.*


### PR DESCRIPTION
For small IoT devices, it would definitely matter if someone needs to introduce Apache Commons Lang (~500KB) to use Felix Health Checks even if none of the other runtime bundles don't use Apache Commons. Therefore, this MR packages all external library packages inside the referenced bundles.