### PR TITLE
[FELIX-6489] ASM - support for Java 18

### DIFF
--- a/tools/org.apache.felix.scr.generator/pom.xml
+++ b/tools/org.apache.felix.scr.generator/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-analysis</artifactId>
-            <version>7.1</version>
+            <version>8.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/tools/org.apache.felix.scr.generator/pom.xml
+++ b/tools/org.apache.felix.scr.generator/pom.xml
@@ -45,7 +45,7 @@
     </scm>
 
     <properties>
-        <felix.java.version>6</felix.java.version>
+        <felix.java.version>7</felix.java.version>
     </properties>
     
     <dependencies>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-analysis</artifactId>
-            <version>8.0</version>
+            <version>9.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -113,7 +113,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.16</version>
+                    <version>1.20</version>
                 </plugin>
 
             </plugins>


### PR DESCRIPTION
Upgrade asm lib to support Java 17.
Currently compiling a project in Java 17 with maven-src-plugin throw an exception:
Unable to scan class files: org.test.Test (Class file format probably not supported by ASM ?): Unsupported class file major version 61 