### PR TITLE
[FELIX-6058] Re-added Bundle-Activator to gogo.jline bundle

### DIFF
--- a/gogo/jline/pom.xml
+++ b/gogo/jline/pom.xml
@@ -88,6 +88,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
+                        <Bundle-Activator>org.apache.felix.gogo.jline.Activator</Bundle-Activator>
                         <Export-Package>
                             org.apache.felix.gogo.jline
                         </Export-Package>


### PR DESCRIPTION
Currently the gogo.jline bundle stand-alone is not usable. There was already an open PR on the felix repo (https://github.com/apache/felix/pull/184), but given the state of the felix repository, this will not get merged.

This PR ensures that the Bundle-Activator headers is set as instruction on the maven-bundle-plugin, making the gogo.jline bundle both usable stand-alone and in the context of Karaf's shell.core where the gogo.jline package is inlined.