### PR TITLE
[FELIX-6274] Add a test demonstrating the LogService ClassCastException

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/logger/ReflectiveR6LogServiceLogger.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/logger/ReflectiveR6LogServiceLogger.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.felix.scr.impl.logger;
+
+import java.lang.reflect.Method;
+
+/**
+ * This is a logger based on the R6 LogService.
+ */
+class ReflectiveR6LogServiceLogger implements InternalLogger
+{
+    private final Method logMethod;
+	private final Object logService;
+
+    public ReflectiveR6LogServiceLogger(final Object logService) throws Exception
+    {
+        this.logService = logService;
+	    logMethod = logService.getClass().getMethod( "log", int.class, String.class, Throwable.class );
+    }
+
+    @Override
+    public boolean isLogEnabled(final int level)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean checkScrConfig() {
+        return true;
+    }
+
+    @Override
+    public void log(final int level, final String message, final Throwable ex)
+    {
+        try {
+            this.logMethod.invoke( logService, level, message, ex );
+        } catch (Throwable e) {
+            new StdOutLogger().log(1, "A serious error ocurred while attempting to log", e);
+        }
+    }
+}

--- a/scr/src/main/java/org/apache/felix/scr/impl/logger/ReflectiveR7LogServiceLogger.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/logger/ReflectiveR7LogServiceLogger.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.felix.scr.impl.logger;
+
+import java.lang.reflect.Method;
+
+import org.osgi.framework.Bundle;
+import org.osgi.service.log.Logger;
+
+/**
+ * This is a logger based on the R7 LogService/LoggerFactory
+ */
+class ReflectiveR7LogServiceLogger implements InternalLogger
+{
+    private final Object logger;
+    private final Method isErrorEnabled;
+    private final Method isWarnEnabled;
+    private final Method isInfoEnabled;
+    private final Method isDebugEnabled;
+
+    private final Method errorString;
+    private final Method warnString;
+    private final Method infoString;
+    private final Method debugString;
+
+    private final Method errorStringEx;
+    private final Method warnStringEx;
+    private final Method infoStringEx;
+    private final Method debugStringEx;
+
+    public ReflectiveR7LogServiceLogger(final Bundle bundle, final Object loggerFactory, final String name) throws Throwable
+    {
+        Class<?> loggerClazz = loggerFactory.getClass().getClassLoader().loadClass( "org.osgi.service.log.LoggerFactory" );
+
+        
+        logger = loggerFactory.getClass().getMethod( "getLogger",  String.class, Class.class )
+        		.invoke( loggerFactory, name == null ? Logger.ROOT_LOGGER_NAME : name, loggerClazz );
+        
+        
+        isErrorEnabled = loggerClazz.getMethod( "isErrorEnabled");
+        isWarnEnabled = loggerClazz.getMethod( "isWarnEnabled" );
+        isInfoEnabled = loggerClazz.getMethod( "isInfoEnabled" );
+        isDebugEnabled = loggerClazz.getMethod( "isDebugEnabled" );
+        
+        errorString = loggerClazz.getMethod( "error", String.class );
+        warnString = loggerClazz.getMethod( "warn", String.class );
+        infoString = loggerClazz.getMethod( "info", String.class );
+        debugString = loggerClazz.getMethod( "debug", String.class );
+
+        errorStringEx = loggerClazz.getMethod( "error", String.class, Throwable.class );
+        warnStringEx = loggerClazz.getMethod( "warn", String.class, Throwable.class );
+        infoStringEx = loggerClazz.getMethod( "info", String.class, Throwable.class );
+        debugStringEx = loggerClazz.getMethod( "debug", String.class, Throwable.class );
+        
+    }
+
+    @Override
+    public boolean checkScrConfig() {
+        return false;
+    }
+
+    @Override
+    public boolean isLogEnabled(final int level)
+    {
+        try 
+        {
+            switch ( level )
+            {
+                case 1 : return (boolean) isErrorEnabled.invoke( logger );
+                case 2 : return (boolean) isWarnEnabled.invoke( logger );
+                case 3 : return (boolean) isInfoEnabled.invoke( logger );
+                default : return (boolean) isDebugEnabled.invoke( logger );
+            }
+        } catch ( Throwable e ) {
+            new StdOutLogger().log( 1, "An error occurred attmepting to determine the enabled log level", e );
+            return false;
+        }
+    }
+
+    @Override
+    public void log(final int level, final String message, final Throwable ex)
+    {
+    	try {
+            if ( ex == null )
+            {
+                switch ( level )
+                {
+                    case 1 : errorString.invoke( logger, message ); break;
+                    case 2 : warnString.invoke( logger, message ); break;
+                    case 3 : infoString.invoke( logger, message ); break;
+                    default : debugString.invoke( logger, message );
+                }
+            }
+            else
+            {
+                switch ( level )
+                {
+                    case 1 : errorStringEx.invoke( logger, message, ex ); break;
+                    case 2 : warnStringEx.invoke( logger, message, ex ); break;
+                    case 3 : infoStringEx.invoke( logger, message, ex ); break;
+                    default : debugStringEx.invoke( logger, message, ex );
+                }
+            }
+    	} catch ( Throwable t ) {
+    		new StdOutLogger().log( 1, "An error occurred attmepting to log a message", t );
+    	}
+    }
+}

--- a/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
@@ -185,6 +185,7 @@ public abstract class ComponentTestBase
                         mavenBundle( "org.apache.felix", "org.apache.felix.configadmin", felixCaVersion ) ),
                         mavenBundle( "org.osgi", "org.osgi.util.promise"),
                         mavenBundle( "org.osgi", "org.osgi.util.function"),
+                        mavenBundle( "org.ops4j.pax.url", "pax-url-aether"),
                 junitBundles(), frameworkProperty( "org.osgi.framework.bsnversion" ).value( bsnVersionUniqueness ),
                 systemProperty( "ds.factory.enabled" ).value( Boolean.toString( NONSTANDARD_COMPONENT_FACTORY_BEHAVIOR ) ),
                 systemProperty( "ds.loglevel" ).value( DS_LOGLEVEL ),
@@ -211,8 +212,10 @@ public abstract class ComponentTestBase
                 ConfigurationAdmin.class, null );
         configAdminTracker.open();
 
-        bundle = installBundle( descriptorFile, COMPONENT_PACKAGE );
-        bundle.start();
+        if( descriptorFile != null ) {
+            bundle = installBundle( descriptorFile, COMPONENT_PACKAGE );
+            bundle.start();
+        }
     }
 
     @After

--- a/scr/src/test/java/org/apache/felix/scr/integration/Felix6274Test.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/Felix6274Test.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.felix.scr.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
+import static org.ops4j.pax.tinybundles.core.TinyBundles.withClassicBuilder;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.Constants;
+import org.osgi.namespace.extender.ExtenderNamespace;
+import org.osgi.service.component.runtime.dto.ComponentConfigurationDTO;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+import org.osgi.service.log.LogService;
+
+@RunWith(PaxExam.class)
+public class Felix6274Test extends ComponentTestBase
+{
+    static
+    {
+        // This test creates its own component bundles
+        descriptorFile = null;
+        DS_LOGLEVEL = "debug";
+        // paxRunnerVmOption = DEBUG_VM_OPTION;
+    }
+
+    private final List<Bundle> installedBundles = new ArrayList<>();
+    private Bundle log_1_4_bundle;
+    private Bundle log_1_3_bundle;
+    
+    @Before
+    public void installBundles() throws BundleException {
+        
+        // Install an older version of the log service 
+        String url = mavenBundle( "org.apache.felix", "org.apache.felix.log", "1.0.1" ).getURL();
+        installedBundles.add( bundleContext.installBundle( url ) );
+
+        // Install the R7 version of the log service 
+        url = mavenBundle( "org.apache.felix", "org.apache.felix.log", "1.2.2" ).getURL();
+        installedBundles.add( bundleContext.installBundle( url ) );
+        
+        log_1_4_bundle = bundleContext.installBundle( "integration.test.6274", 
+                createStream( "6274", "[1.4,1.5)" ) );
+        installedBundles.add( log_1_4_bundle );
+
+        log_1_3_bundle = bundleContext.installBundle( "integration.test.6274_2", 
+                createStream( "6274_2", "[1.3,1.4)" ) );
+        installedBundles.add( log_1_3_bundle );
+
+        for( Bundle b : installedBundles ) {
+            b.start();
+        }
+    }
+    
+    @After
+    public void cleanUpBundles() {
+        for( Bundle b : installedBundles ) {
+            try {
+                b.uninstall();
+            } catch ( BundleException be ) {
+                // Just swallow this and keep going
+            }
+        }
+    }
+    
+    private InputStream createStream(String testNumber, String logImportVersionRange) {
+        String classFilePath = "org/apache/felix/scr/integration/components/felix" + testNumber + "/Component.class";
+        String componentXML = "integration_test_FELIX_" + testNumber + ".xml";
+        
+        System.out.println("Located descriptor " + getClass().getResource( "/" + componentXML ) );
+        
+        return bundle().add("OSGI-INF/components.xml", getClass().getResource( "/" + componentXML ) )
+                .add(classFilePath, getClass().getResource( "/" + classFilePath ) )
+
+                .set( Constants.BUNDLE_MANIFESTVERSION, "2" )
+                .set( Constants.BUNDLE_SYMBOLICNAME, "integration.test." + testNumber )
+                .set( Constants.BUNDLE_VERSION, "1.0.0" )
+                .set( Constants.IMPORT_PACKAGE, "org.osgi.service.log;version=\"" + logImportVersionRange + "\"" )
+                .set( "Service-Component", "OSGI-INF/components.xml" )
+                .set( Constants.REQUIRE_CAPABILITY, ExtenderNamespace.EXTENDER_NAMESPACE
+                                + ";filter:=\"(&(osgi.extender=osgi.component)(version>=1.4)(!(version>=2.0)))\"" )
+                .build( withClassicBuilder() );
+    }
+    
+    @Test
+    public void test_incompatible_log_service_version() throws Exception
+    {
+        
+        delay();
+
+        // Locate the components
+        ComponentDescriptionDTO log_1_4_dto = scrTracker.getService().getComponentDescriptionDTO(
+                log_1_4_bundle, "R7LoggerComponent" );
+
+        ComponentDescriptionDTO log_1_3_dto = scrTracker.getService().getComponentDescriptionDTO(
+                log_1_3_bundle, "LogServiceComponent" );
+
+        assertNotNull( "No Log 1.4 Component DTO", log_1_4_dto );
+        assertNotNull( "No Log 1.3 Component DTO", log_1_3_dto );
+
+        // Get the runtime instance data
+        Collection<ComponentConfigurationDTO> running_1_4_components = scrTracker.getService()
+                .getComponentConfigurationDTOs( log_1_4_dto );
+        
+        Collection<ComponentConfigurationDTO> running_1_3_components = scrTracker.getService()
+                .getComponentConfigurationDTOs( log_1_3_dto );
+        
+        assertEquals( 1, running_1_4_components.size() );
+        assertEquals( 1, running_1_3_components.size() );
+        
+        // Check the components are active
+        assertEquals( "1.4 Log Service Component failed to activate", 
+                ComponentConfigurationDTO.ACTIVE, running_1_4_components.iterator().next().state );
+        log.log( LogService.LOG_INFO, "R7LoggerComponent checked active" );
+        
+        assertEquals( "1.3 Log Service Component failed to activate", 
+                ComponentConfigurationDTO.ACTIVE, running_1_3_components.iterator().next().state);
+        log.log( LogService.LOG_INFO, "LogServiceComponent checked active" );
+        
+    }
+}

--- a/scr/src/test/java/org/apache/felix/scr/integration/components/felix6274/Component.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/components/felix6274/Component.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.felix.scr.integration.components.felix6274;
+
+import org.osgi.service.log.Logger;
+
+public class Component
+{
+
+	Logger logger;
+	
+    void activate()
+    {
+        logger.info("Hello from felix6274");
+    }
+
+}

--- a/scr/src/test/java/org/apache/felix/scr/integration/components/felix6274_2/Component.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/components/felix6274_2/Component.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.felix.scr.integration.components.felix6274_2;
+
+import org.osgi.service.log.LogService;
+
+public class Component
+{
+
+	LogService logger;
+	
+    void activate()
+    {
+        logger.log(LogService.LOG_INFO, "Hello from felix6274_2");
+    }
+
+}

--- a/scr/src/test/resources/integration_test_FELIX_6274.xml
+++ b/scr/src/test/resources/integration_test_FELIX_6274.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+        http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<components xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0">
+
+    <scr:component name="R7LoggerComponent">
+        <implementation class="org.apache.felix.scr.integration.components.felix6274.Component" />
+        <reference name="LOG" interface="org.osgi.service.log.LoggerFactory" field="logger"/>
+    </scr:component>
+        
+</components>

--- a/scr/src/test/resources/integration_test_FELIX_6274_2.xml
+++ b/scr/src/test/resources/integration_test_FELIX_6274_2.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+        http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<components xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0">
+
+    <scr:component name="LogServiceComponent">
+        <implementation class="org.apache.felix.scr.integration.components.felix6274_2.Component" />
+        <reference name="LOG" interface="org.osgi.service.log.LogService" field="logger"/>
+    </scr:component>
+        
+</components>


### PR DESCRIPTION
Create a simple test which shows component bundles using different incompatible versions of the log service
can't be properly handled by Felix SCR due to a ClassCastException

Signed-off-by: Tim Ward <timothyjward@apache.org>