### PR TITLE
[FELIX-6282] Added core R7 dependency in pom. Exports R7 api to allow …

### DIFF
--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -58,13 +58,7 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
-            <version>6.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
-            <version>5.0.0</version>
+            <version>7.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -169,7 +163,7 @@
                         <Bundle-SymbolicName>org.apache.felix.connect</Bundle-SymbolicName>
                         <Bundle-Name>Pojo Service Registry</Bundle-Name>
                         <Bundle-Vendor>Apache Software Foundation</Bundle-Vendor>
-                        <Private-Package>
+                        <Export-Package>
                             org.osgi.framework.*,
                             org.osgi.resource,
                             org.osgi.dto,
@@ -178,8 +172,8 @@
                             org.osgi.service.packageadmin,
                             org.osgi.service.startlevel,
                             org.osgi.util.tracker,
-                            org.apache.felix.connect.*
-                        </Private-Package>
+                            org.apache.felix.connect.*;version=${project.version}
+                        </Export-Package>
                         <Import-Package>!*</Import-Package>
                         <Include-Resource>
                             META-INF/LICENSE=LICENSE,META-INF/NOTICE=NOTICE,META-INF/DEPENDENCIES=DEPENDENCIES,{src/main/resources/}

--- a/connect/src/main/java/org/apache/felix/connect/felix/framework/DTOFactory.java
+++ b/connect/src/main/java/org/apache/felix/connect/felix/framework/DTOFactory.java
@@ -41,6 +41,7 @@ import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.framework.wiring.dto.BundleRevisionDTO;
 import org.osgi.framework.wiring.dto.BundleWireDTO;
 import org.osgi.framework.wiring.dto.BundleWiringDTO;
+import org.osgi.framework.wiring.dto.FrameworkWiringDTO;
 import org.osgi.framework.wiring.dto.BundleWiringDTO.NodeDTO;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
@@ -112,6 +113,10 @@ public class DTOFactory
         else if (type == FrameworkStartLevelDTO.class && bundle instanceof Framework)
         {
             return type.cast(createFrameworkStartLevelDTO((Framework) bundle));
+        }
+        else if (type == FrameworkWiringDTO.class)
+        {
+            return type.cast(createFrameworkWiringDTO(bundle));
         }
         return null;
     }
@@ -395,6 +400,23 @@ public class DTOFactory
         FrameworkStartLevelDTO dto = new FrameworkStartLevelDTO();
         dto.initialBundleStartLevel = fsl.getInitialBundleStartLevel();
         dto.startLevel = fsl.getStartLevel();
+
+        return dto;
+    }
+
+    private static FrameworkWiringDTO createFrameworkWiringDTO(Bundle framework)
+    {
+        FrameworkWiringDTO dto = new FrameworkWiringDTO();
+
+        dto.resources = new HashSet<BundleRevisionDTO>();
+        dto.wirings = new HashSet<NodeDTO>();
+
+        Set<Bundle> bundles = new LinkedHashSet<Bundle>(Arrays.asList(framework.getBundleContext().getBundles()));
+
+        for (Bundle bundle : bundles)
+        {
+            addBundleWiring(bundle, dto.resources, dto.wirings);
+        }
 
         return dto;
     }


### PR DESCRIPTION
…to resolve the connect bundle from an OBR. Avoid NPE when adapting system bundle to FrameworkWiringDTO.

This PR provides three things:

1) in the connect/pom.xml, depend on org.osgi:osgi.core:7.0.0

2) you will notice another thing: in the pom.xml, the OSGI and Felix Connect APIs are now exported. You might wonder why: It is just to allow to resolve the Felix Connect bundle as well as OSGI API from an OBR. In my case, some or our application dependencies are calculated by an offline OSGI resolver that pulls dependencies from an OBR. So far, it was not possible to resolve the Apache Felix Connect bundle from the OBR, because all packages were private. Exporting the connect packages (as well as the OSGI packages) allows to make the bundle resolvable from OBR.

3) Added small patch in DTOFactory.java to add support for FrameworkWiringDTO. It's probably useless in context on FelixConnect to support such dto, but at least the patch avoids an NPE when someone tries to adapt the FrameworkWiringDTO from the system bundle.