### PR TITLE
[FELIX-6218] Remove kxml notice

### DIFF
--- a/scr/src/main/appended-resources/META-INF/DEPENDENCIES
+++ b/scr/src/main/appended-resources/META-INF/DEPENDENCIES
@@ -9,10 +9,6 @@ The OSGi Alliance (http://www.osgi.org/).
 Copyright (c) OSGi Alliance (2000, 2009).
 Licensed under the Apache License 2.0. 
 
-This product includes software from http://kxml.sourceforge.net.
-Copyright (c) 2002,2003, Stefan Haustein, Oberhausen, Rhld., Germany.
-Licensed under BSD License.
-
 II. Used Software
 
 This product uses software developed at
@@ -27,4 +23,3 @@ Licensed under the Apache License 2.0.
 
 III. License Summary
 - Apache License 2.0
-- BSD License

--- a/scr/src/main/appended-resources/META-INF/LICENSE
+++ b/scr/src/main/appended-resources/META-INF/LICENSE
@@ -6,26 +6,3 @@ The Apache Felix Declarative Services includes a number of subcomponents with
 separate copyright notices and license terms. Your use of the source
 code for the these subcomponents is subject to the terms and
 conditions of the following licenses. 
-
-
-For the KXml component:
-
-Copyright (c) 2002,2003, Stefan Haustein, Oberhausen, Rhld., Germany
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or
-sell copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The  above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-IN THE SOFTWARE. 


### PR DESCRIPTION
FELIX-6218 removed kxml from packaging, but did not update DEPENDENCIES and LICENSE. This patch finishes that up.