### PR TITLE
[FELIX-6297] MultiReleaseContent leaks manifest InputStream

### DIFF
--- a/framework/src/main/java/org/apache/felix/framework/util/MultiReleaseContent.java
+++ b/framework/src/main/java/org/apache/felix/framework/util/MultiReleaseContent.java
@@ -63,12 +63,14 @@ public class MultiReleaseContent implements Content
         {
             try
             {
-                InputStream manifestStream = content.getEntryAsStream("META-INF/MANIFEST.MF");
-                if (manifestStream != null)
+                try (InputStream manifestStream = content.getEntryAsStream("META-INF/MANIFEST.MF"))
                 {
-                    if ("true".equals(new Manifest(manifestStream).getMainAttributes().getValue("Multi-Release")))
+                    if (manifestStream != null)
                     {
-                        content = new MultiReleaseContent(javaVersion, content);
+                        if ("true".equals(new Manifest(manifestStream).getMainAttributes().getValue("Multi-Release")))
+                        {
+                            content = new MultiReleaseContent(javaVersion, content);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
add try-with-resources to close InputStream that's otherwise leaked.