### PR TITLE
FELIX-6315: do not deactivate factory component configurations

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/manager/SingleComponentManager.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/manager/SingleComponentManager.java
@@ -1040,7 +1040,8 @@ public class SingleComponentManager<S> extends AbstractComponentManager<S> imple
             // unget the service instance if no bundle is using it
             // any longer unless delayed component instances have to
             // be kept (FELIX-3039)
-            if (  m_useCount.decrementAndGet() == 0 && !isImmediate() && !keepInstances() )
+            if ( m_useCount.decrementAndGet() == 0 && !isImmediate()
+                    && !getComponentMetadata().isFactory() && !keepInstances() )
             {
                 final State previousState = getState();
                 deleteComponent( ComponentConstants.DEACTIVATION_REASON_UNSPECIFIED );


### PR DESCRIPTION
Reaching zero reference count for a component configuration created
via a component factory should not trigger that configuration being
deactivated.