### PR TITLE
FELIX-6317 - Ensure the order of dynamic binding follows service rank

### DIFF
--- a/scr/src/test/java/org/apache/felix/scr/integration/components/felix3680_2/Main.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/components/felix3680_2/Main.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.felix.scr.impl.manager.ThreadDump;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;


### PR DESCRIPTION
If multiple threads register higher ranked services than
the currently bound service then a single thread is
selected to do the work of binding the highest ranked
service. The other threads just queue up the possible
service to be bound by the winning thread.

This ensures that the component will not
get out of order bindings for the various service
registration when a component has a dynamic, greedy reference
with cardinality of 0..1 or 1..1

A new testcase is added that registers 100 services with
different ranks using 10 threads. The test then confirms
that the highest ranked service is the current one bound
to the component. Theoretically the test could pass before
this fix, but multiple runs without the fix never resulted
in a passing test.