### PR TITLE
FELIX-6318: Fix tiny thread safety bug in BundleWiringImpl::getClassLoader

### DIFF
--- a/framework/src/main/java/org/apache/felix/framework/BundleWiringImpl.java
+++ b/framework/src/main/java/org/apache/felix/framework/BundleWiringImpl.java
@@ -711,7 +711,7 @@ public class BundleWiringImpl implements BundleWiring
     private ClassLoader getClassLoaderInternal()
     {
         ClassLoader classLoader = m_classLoader;
-        if (m_classLoader != null)
+        if (classLoader != null)
         {
             return classLoader;
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FELIX-6318