### PR TITLE
FELIX-6321 - keep existing LogManager on config update

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/Activator.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/Activator.java
@@ -652,14 +652,16 @@ public class Activator extends AbstractExtender
         }
     }
 
-    public void resetLogger()
+    public void setLogger()
     {
-        // reset existing logger
-        ScrLogger existingLogger = logger;
-        if (existingLogger != null)
+        // TODO we only set the logger once
+        // If the need arises to be able to dynamically set the logger type
+        // then more work is needed to do that switch
+        // for now we only can configure ds.log.extension with context properties
+        if (logger == null)
         {
-            existingLogger.close();
+            logger = ScrLogManager.scr(m_context, m_configuration);
         }
-        logger = ScrLogManager.scr(m_context, m_configuration);
+
     }
 }

--- a/scr/src/main/java/org/apache/felix/scr/impl/config/ScrConfigurationImpl.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/config/ScrConfigurationImpl.java
@@ -222,7 +222,7 @@ public class ScrConfigurationImpl implements ScrConfiguration
             oldGlobalExtender = this.globalExtender;
             this.globalExtender = newGlobalExtender;
         }
-        activator.resetLogger();
+        activator.setLogger();
         if ( newGlobalExtender != oldGlobalExtender )
         {
             activator.restart( newGlobalExtender );

--- a/scr/src/main/java/org/apache/felix/scr/impl/logger/ExtLogManager.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/logger/ExtLogManager.java
@@ -52,7 +52,7 @@ class ExtLogManager extends ScrLogManager {
 
 	@Override
 	public BundleLogger bundle(Bundle bundle) {
-		return getLogger(this.bundle, SCR_LOGGER_PREFIX.concat(bundle.getSymbolicName()), ScrLoggerFacade.class);
+		return getLogger(bundle, SCR_LOGGER_PREFIX.concat(bundle.getSymbolicName()), ScrLoggerFacade.class);
 	}
 
 	@Override

--- a/scr/src/main/java/org/apache/felix/scr/impl/logger/LogManager.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/logger/LogManager.java
@@ -160,7 +160,6 @@ class LogManager extends ServiceTracker<LoggerFactory, LoggerFactory> implements
 
 		LogDomain(Bundle bundle) {
 			this.bundle = bundle;
-			open();
 		}
 
 		private void reset() {

--- a/scr/src/main/java/org/apache/felix/scr/impl/logger/ScrLogManager.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/logger/ScrLogManager.java
@@ -52,10 +52,13 @@ public class ScrLogManager extends LogManager {
 	 */
 
 	public static ScrLogger scr(BundleContext context, ScrConfiguration config) {
+        ScrLogManager manager;
 		if (config.isLogExtension())
-			return new ExtLogManager(context, config).scr();
+            manager = new ExtLogManager(context, config);
 		else
-			return new ScrLogManager(context, config).scr();
+            manager = new ScrLogManager(context, config);
+        manager.open();
+        return manager.scr();
 	}
 
 	ScrLogManager(BundleContext context, ScrConfiguration config) {

--- a/scr/src/test/java/org/apache/felix/scr/impl/logger/LoggerTest.java
+++ b/scr/src/test/java/org/apache/felix/scr/impl/logger/LoggerTest.java
@@ -118,6 +118,7 @@ public class LoggerTest {
 		ScrConfiguration config = mock(ScrConfiguration.class);
 		when(config.getLogLevel()).thenReturn(Level.DEBUG);
 		ExtLogManager elm = new ExtLogManager(scr.getBundleContext(), config);
+        elm.open();
 
 		ComponentLogger clog = elm.component(component, "i.c", "c");
 
@@ -131,6 +132,7 @@ public class LoggerTest {
 		ScrConfiguration config = mock(ScrConfiguration.class);
 		when(config.getLogLevel()).thenReturn(Level.DEBUG);
 		ExtLogManager elm = new ExtLogManager(scr.getBundleContext(), config);
+        elm.open();
 		try (Buf out = new Buf(System.out);
 				Buf err = new Buf(System.err);) {
 			try {
@@ -191,7 +193,7 @@ public class LoggerTest {
 		bundle.log(Level.ERROR, "Ext", null);
 		assertThat(l.entries).hasSize(1);
 		LogEntry le = l.entries.get(0);
-		assertThat(le.bundle).isEqualTo(scr);
+        assertThat(le.bundle).isEqualTo(component);
 	}
 
 	@Test
@@ -263,6 +265,7 @@ public class LoggerTest {
 		l.register();
 
 		ScrLogManager lm = new ExtLogManager(scr.getBundleContext(), config);
+        lm.open();
 
 		{
 			l.entries.clear();
@@ -282,7 +285,7 @@ public class LoggerTest {
 			assertThat(l.entries).hasSize(1);
 			LogEntry le = l.entries.get(0);
 			assertThat(le.format).isEqualTo("Bundle");
-			assertThat(le.bundle).isEqualTo(scr);
+            assertThat(le.bundle).isEqualTo(component);
 			assertThat(le.loggername).isEqualTo(ExtLogManager.SCR_LOGGER_PREFIX + "component");
 		}
 
@@ -318,6 +321,7 @@ public class LoggerTest {
 		l.register();
 
 		ScrLogManager lm = new ScrLogManager(scr.getBundleContext(), config);
+        lm.open();
 
 		{
 			l.entries.clear();
@@ -363,6 +367,7 @@ public class LoggerTest {
 	public void testLifeCycle() {
 
 		LogManager lm = new LogManager(scr.getBundleContext());
+        lm.open();
 		LoggerFacade facade = lm.getLogger(scr, "lifecycle", LoggerFacade.class);
 		assertThat(facade.logger).isNull();
 
@@ -398,6 +403,7 @@ public class LoggerTest {
 	public void testPrioritiesLogService() {
 
 		LogManager lm = new LogManager(scr.getBundleContext());
+        lm.open();
 		LoggerFacade facade = lm.getLogger(scr, "lifecycle", LoggerFacade.class);
 		assertThat(facade.logger).isNull();
 
@@ -430,6 +436,7 @@ public class LoggerTest {
 		l.register();
 
 		ScrLogManager lm = new ScrLogManager(scr.getBundleContext(), config);
+        lm.open();
 		lm.component(component, "implementation.class", "component");
 
 		assertThat(lm.lock.domains).hasSize(1);
@@ -457,6 +464,7 @@ public class LoggerTest {
 		l.register();
 
 		ScrLogManager lm = new ScrLogManager(scr.getBundleContext(), config);
+        lm.open();
 		ScrLogger facade = lm.scr();
 
 		assert LogLevel.values().length == Level.values().length;


### PR DESCRIPTION
Replacing the existing LogManager with a new one on
configuration updates causes the existing loggers for
each component to stop working properly.  This is a quick
fix to avoid creating a new LogManager on config updates
of SCR.  If dynamic updates is needed for the ds.log.extension
property then more work is needed.  For now this is a
one time setting only configured through context properties