### PR TITLE
FELIX-6327 - NoSuchElementException when services are removed

### DIFF
--- a/scr/src/test/java/org/apache/felix/scr/integration/components/SimpleComponent.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/components/SimpleComponent.java
@@ -41,7 +41,7 @@ public class SimpleComponent
 
     public static final Set<SimpleComponent> PREVIOUS_INSTANCES = new HashSet<SimpleComponent>();
 
-    public static SimpleComponent INSTANCE;
+    public volatile static SimpleComponent INSTANCE;
 
     private Map<?, ?> m_config;
 
@@ -49,11 +49,11 @@ public class SimpleComponent
 
     public ComponentContext m_activateContext;
 
-    public SimpleService m_singleRef;
+    public volatile SimpleService m_singleRef;
 
-    public int m_singleRefBind = 0;
+    public volatile int m_singleRefBind = 0;
 
-    public int m_singleRefUnbind = 0;
+    public volatile int m_singleRefUnbind = 0;
 
     public final Set<SimpleService> m_multiRef = new HashSet<SimpleService>();
 

--- a/scr/src/test/java/org/apache/felix/scr/integration/components/SimpleServiceImpl.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/components/SimpleServiceImpl.java
@@ -21,14 +21,13 @@ package org.apache.felix.scr.integration.components;
 
 import java.util.Dictionary;
 import java.util.Hashtable;
-import java.util.Properties;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceRegistration;
 
 
-public class SimpleServiceImpl implements SimpleService
+public class SimpleServiceImpl implements SimpleService, Comparable<SimpleServiceImpl>
 {
 
     private String m_value;
@@ -37,7 +36,7 @@ public class SimpleServiceImpl implements SimpleService
 
     private String m_filterProp;
 
-    private ServiceRegistration m_registration;
+    private ServiceRegistration<SimpleService> m_registration;
 
 
     public static SimpleServiceImpl create( BundleContext bundleContext, String value )
@@ -50,7 +49,8 @@ public class SimpleServiceImpl implements SimpleService
     {
         SimpleServiceImpl instance = new SimpleServiceImpl( value, ranking );
         Dictionary<String,?> props = instance.getProperties();
-        instance.setRegistration( bundleContext.registerService( SimpleService.class.getName(), instance, props ) );
+        instance.setRegistration(
+            bundleContext.registerService(SimpleService.class, instance, props));
         return instance;
     }
 
@@ -104,7 +104,7 @@ public class SimpleServiceImpl implements SimpleService
 
     public SimpleServiceImpl drop()
     {
-        ServiceRegistration sr = getRegistration();
+        ServiceRegistration<SimpleService> sr = getRegistration();
         if ( sr != null )
         {
             setRegistration( null );
@@ -120,14 +120,15 @@ public class SimpleServiceImpl implements SimpleService
     }
 
 
-    public SimpleServiceImpl setRegistration( ServiceRegistration registration )
+    public SimpleServiceImpl setRegistration(
+        ServiceRegistration<SimpleService> registration)
     {
         m_registration = registration;
         return this;
     }
 
 
-    public ServiceRegistration getRegistration()
+    public ServiceRegistration<SimpleService> getRegistration()
     {
         return m_registration;
     }
@@ -136,6 +137,13 @@ public class SimpleServiceImpl implements SimpleService
     @Override
     public String toString()
     {
-        return getClass().getSimpleName() + ": value=" + getValue() + ", filterprop=" + m_filterProp;
+        return getClass().getSimpleName() + ": value=" + getValue() + ", filterprop="
+            + m_filterProp + ", m_registration=" + m_registration;
+    }
+
+    @Override
+    public int compareTo(SimpleServiceImpl o)
+    {
+        return Integer.compare(this.m_ranking, o.m_ranking);
     }
 }


### PR DESCRIPTION
The tryInvokeBind method needs more safeguards around when the reference
that just got bound is detected that it got removed.

The previous code always assumed there was at least one other viable
reference to bind to.  That causes the NoSuchElementException when
trying to find a fallback reference.  Fixing that exposed another issue
with the previous code where the state of the DependencyManager is not
properly restored in two aspects:

1) Even when unbind is not invoked during tryInvokeBind the
currentRefPair would get set to null when it must remain set to the
previous value in cases where the invoke bind fails.  A check is needed
to be sure to only clear the currentRefPair if unbind was successfully
invoked.

2) After invoking bind/unbind there is a check to see if the reference
is still viable (not deleted).  This is where the reported problem
occurs when there is no alternative reference available and a
NoSuchElementException is thrown.  Avoiding the NoSuchElementException
and returning from tryInvokeBind would leave the DependencyManager in a
state where it thinks there is still a binding thread doing work when
that thread is really done.  Additional checks are needed to ensure we
always restore the binding thread state of the DepenencyManager on exit
of tryInvokeBind method.