### PR TITLE
[FELIX-6332] AttributeDefinition options should return null when not present

### DIFF
--- a/metatype/src/main/java/org/apache/felix/metatype/AD.java
+++ b/metatype/src/main/java/org/apache/felix/metatype/AD.java
@@ -207,6 +207,12 @@ public class AD extends OptionalAttributes
      */
     public void setOptions(Map options)
     {
+        if (options.size() == 0) {
+            optionLabels = null;
+            optionValues = null;
+            return;
+        }
+
         optionLabels = new String[options.size()];
         optionValues = new String[options.size()];
         int i = 0;


### PR DESCRIPTION
OSGi Compendium 7.0.0, 105.14.2.18 and 105.14.2.19 specify that if the
function returns null, there are no option values or labels available.

Currently, these get set to String[0] because the options map.size()
returns 0.