### PR TITLE
[FELIX-6338] Prevent Null pointer exception in fileinstall watcher

### DIFF
--- a/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/Watcher.java
+++ b/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/Watcher.java
@@ -176,7 +176,11 @@ public abstract class Watcher implements Closeable {
 
                 // Context for directory entry event is the file name of entry
                 Path name = ev.context();
-                Path child = dir.resolve(name);
+                Path child = null;
+
+                if(name!=null){
+                    child = dir.resolve(name);
+                }
 
                 debug("Processing event {} on path {}", kind, child);
 


### PR DESCRIPTION
An OVERFLOW event might have a context that is null. As a consequence the Path.resolve call will throw a null pointer exception

See https://issues.apache.org/jira/browse/FELIX-6338