### PR TITLE
[FELIX-6337] Maven Bundle Plugin generates incorrect Provide-Capability

### DIFF
--- a/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
+++ b/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
@@ -1183,8 +1183,7 @@ public class BundlePlugin extends AbstractMojo
 
             for ( String header : Arrays.asList( Constants.IMPORT_PACKAGE, Constants.DYNAMICIMPORT_PACKAGE,
                                                  Constants.EXPORT_PACKAGE, Constants.PRIVATE_PACKAGE,
-                                                 Constants.PROVIDE_CAPABILITY, Constants.REQUIRE_CAPABILITY,
-                                                 "Bundle-Blueprint", "Service-Component" ) )
+                                                 Constants.REQUIRE_CAPABILITY, "Bundle-Blueprint", "Service-Component" ) )
             {
                 reformatClauses( bundleManifest.getMainAttributes(), header );
             }


### PR DESCRIPTION
In reformatClauses() OSGiHeader.parseHeader() is cutting off "List<String>" from "objectClass:List<String>", that leads to incorrect Provide-Capabilities to be generated.