### PR TITLE
[FELIX-6337] Maven Bundle Plugin generates incorrect Provide-Capability

### DIFF
--- a/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
+++ b/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
@@ -1223,6 +1223,17 @@ public class BundlePlugin extends AbstractMojo
                 Map<String, String> newAttrs = new TreeMap<>(
                             Comparator.<String, Boolean>comparing( s -> !s.endsWith( ":" ) ).thenComparing( s -> s ) );
                 newAttrs.putAll( attrs );
+
+                // OSGiHeader.parseHeader() is cutting off List<String>
+                if (name.equals(Constants.PROVIDE_CAPABILITY)) {
+                    String objectClassValue = attrs.get("objectClass");
+                    if (objectClassValue.contains(",")) {
+                        String newKey = "objectClass:List<String>";
+                        newAttrs.remove("objectClass");
+                        newAttrs.put(newKey, objectClassValue);
+                    }
+                }
+
                 sorted.put( key, newAttrs );
             }
             String nh = new Parameters( sorted ).toString();


### PR DESCRIPTION
OSGiHeader.parseHeader() is cutting off "List" from "objectClass:List", that leads to incorrect Provide-Capabilities to be generated.