### PR TITLE
FELIX-6416 Fix url handling

### DIFF
--- a/framework/src/main/java/org/apache/felix/framework/URLHandlersBundleURLConnection.java
+++ b/framework/src/main/java/org/apache/felix/framework/URLHandlersBundleURLConnection.java
@@ -46,9 +46,7 @@ class URLHandlersBundleURLConnection extends URLConnection
     {
         super(url);
 
-        String urlString = url.toExternalForm();
-
-        m_path = urlString.substring(urlString.indexOf(url.getPath()));
+        m_path = url.getPath();
 
         // If this is an attempt to create a connection to the root of
         // the bundle, then throw an exception since this isn't possible.


### PR DESCRIPTION
Not sure if is safe to have just url.getPath() as I am not Felix Framework expert.
But even if this PR is not suitable for merge, at least it has test coverage for the scenario encountered and rolls back the cause of it.
Would be good to back port that to 6.0.5 release which can be used by Karaf 4.3.X release as it is blocker for Narayana and possibly some other libs.
It is also blocking KARAF-7152.

But indeed it is rendering FELIX-6326 broken again AFAIK