### PR TITLE
Introduced thread-safety while updating field during deactivation phase

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/inject/field/FieldHandler.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/inject/field/FieldHandler.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -42,7 +43,6 @@ import org.apache.felix.scr.impl.logger.ComponentLogger;
 import org.apache.felix.scr.impl.logger.InternalLogger.Level;
 import org.apache.felix.scr.impl.metadata.ReferenceMetadata;
 import org.osgi.framework.BundleContext;
-import org.osgi.service.log.LogLevel;
 
 /**
  * Handler for field references
@@ -186,15 +186,19 @@ public class FieldHandler
         	// unbind needs only be done, if reference is dynamic and optional
             if ( mType == METHOD_TYPE.UNBIND )
             {
-                if ( this.metadata.isOptional() && !this.metadata.isStatic() )
+                Map<RefPair<?, ?>, Object> boundValues = bp.getComponentContext().getBoundValues(metadata.getName());
+                synchronized (boundValues) 
                 {
-                    // we only reset if it was previously set with this value
-                    if ( bp.getComponentContext().getBoundValues(metadata.getName()).size() == 1 )
+                    if ( this.metadata.isOptional() && !this.metadata.isStatic() )
                     {
-                        this.setFieldValue(componentInstance, null);
+                        // we only reset if it was previously set with this value
+                        if ( boundValues.size() == 1 )
+                        {
+                            this.setFieldValue(componentInstance, null);
+                        }
                     }
+                    boundValues.remove(refPair);
                 }
-                bp.getComponentContext().getBoundValues(metadata.getName()).remove(refPair);
             }
             // updated needs only be done, if the value type is map or tuple
             // If it's a dynamic reference, the value can be updated

--- a/scr/src/main/java/org/apache/felix/scr/impl/manager/ComponentContextImpl.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/manager/ComponentContextImpl.java
@@ -19,7 +19,7 @@
 package org.apache.felix.scr.impl.manager;
 
 
-import java.util.Comparator;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Map;
@@ -328,15 +328,6 @@ public class ComponentContextImpl<S> implements ScrComponentContext {
 
     private Map<RefPair<?, ?>, Object> createNewFieldHandlerMap()
     {
-        return new TreeMap<>(
-            new Comparator<RefPair<?, ?>>()
-            {
-
-                @Override
-                public int compare(final RefPair<?, ?> o1, final RefPair<?, ?> o2)
-                {
-                    return o1.getRef().compareTo(o2.getRef());
-                }
-            });
+        return Collections.synchronizedMap(new TreeMap<>((o1, o2) -> o1.getRef().compareTo(o2.getRef())));
     }
 }


### PR DESCRIPTION
The problem occurred when multiple injected services tried to be removed from the component's injection. It is highly likely because of the usage of `TreeMap` in such concurrent environment. Since `TreeMap` has never been written to be used in a concurrent environment, we should use `ConcurrentSkipListMap` instead as all the features of `TreeMap` have been introduced in `ConcurrentSkipListMap` and it is very much suitable for concurrent environment.