### PR TITLE
Feature - remove imports from `cm.json.impl.JsonSupport`

### DIFF
--- a/cm.json/src/main/java/org/apache/felix/cm/json/Configurations.java
+++ b/cm.json/src/main/java/org/apache/felix/cm/json/Configurations.java
@@ -21,6 +21,7 @@ package org.apache.felix.cm.json;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Hashtable;
+import java.util.Map;
 
 import javax.json.JsonValue;
 
@@ -28,6 +29,7 @@ import org.apache.felix.cm.json.impl.ConfigurationReaderImpl;
 import org.apache.felix.cm.json.impl.ConfigurationWriterImpl;
 import org.apache.felix.cm.json.impl.JsonSupport;
 import org.apache.felix.cm.json.impl.OrderedDictionary;
+import org.apache.felix.cm.json.impl.TypeConverter;
 
 /**
  * Factory class for JSON and configuration support
@@ -119,5 +121,18 @@ public class Configurations {
      */
     public static JsonValue convertToJsonValue(final Object value) {
         return JsonSupport.convertToJson(value);
+    }
+    
+    /**
+     * Convert name and value of on attribute to a {@code Map.Entry<String, JsonValue>} with an typed name as key.
+     *
+     * @param name The (untyped) name to attribute
+     * @param value The value to attribute
+     *
+     * @return A Entry<String, JsonValue> where the key contains the key:type info and the value the
+     *         converted JsonValue.
+     */    
+	public static Map.Entry<String, JsonValue>convertToTypedJsonEntry(String name, final Object value) {
+        return TypeConverter.convertToTypedJsonEntry(name,value);
     }
 }

--- a/cm.json/src/main/java/org/apache/felix/cm/json/impl/ConfigurationWriterImpl.java
+++ b/cm.json/src/main/java/org/apache/felix/cm/json/impl/ConfigurationWriterImpl.java
@@ -92,14 +92,9 @@ public class ConfigurationWriterImpl
             final String name = e.nextElement();
             final Object value = properties.get(name);
 
-            final Map.Entry<String, JsonValue> entry = TypeConverter.convertObjectToTypedJsonValue(value);
-            final String key;
-            if (TypeConverter.NO_TYPE_INFO.equals(entry.getKey())) {
-                key = name;
-            } else {
-                key = name.concat(":").concat(entry.getKey());
-            }
-            generator.write(key, entry.getValue());
+            final Map.Entry<String, JsonValue> entry = TypeConverter.convertToTypedJsonEntry(name, value);
+
+            generator.write(entry.getKey(), entry.getValue());
         }
         generator.writeEnd();
     }

--- a/cm.json/src/main/java/org/apache/felix/cm/json/impl/TypeConverter.java
+++ b/cm.json/src/main/java/org/apache/felix/cm/json/impl/TypeConverter.java
@@ -19,6 +19,7 @@
 package org.apache.felix.cm.json.impl;
 
 import java.lang.reflect.Array;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -241,6 +242,28 @@ public class TypeConverter {
 
         return new Entry(NO_TYPE_INFO, JsonSupport.convertToJson(value));
     }
+
+    /**
+     * Convert name and value of on attribute to a {@code Map.Entry<String, JsonValue>} with an typed name as key.
+     *
+     * @param name The (untyped) name to attribute
+     * @param value The value to attribute
+     *
+     * @return A Entry<String, JsonValue> where the key contains the key:type info and the value the
+     *         converted JsonValue.
+     */   
+	public static Map.Entry<String, JsonValue> convertToTypedJsonEntry(final String name, Object value) {
+
+		final Map.Entry<String, JsonValue> entry = convertObjectToTypedJsonValue(value);
+		final String key;
+		if (TypeConverter.NO_TYPE_INFO.equals(entry.getKey())) {
+			key = name;
+		} else {
+			key = name.concat(":").concat(entry.getKey());
+		}
+		return new AbstractMap.SimpleEntry<String,JsonValue>(key, entry.getValue());
+
+	}
 
     private static final class Entry implements Map.Entry<String, JsonValue> {
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.cm.json</artifactId>
-            <version>1.0.6</version>
+            <version>1.0.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
The Feature-Bundle imports `cm.json.impl` because it is using `JsonSupport` and `TypeConverter` but this package is not exported by cm.

* `JsonSupport` - could be replaced using the existing  `cm.json` API.
* `TypeConverter` - could not find a way to do this with the existing API added `Configurations.convertToTypedJsonEntry`

@bosschaert could you please review?