### PR TITLE
FELIX-6474 - Improve HealthCheckResultCacheTest

### DIFF
--- a/healthcheck/core/src/main/java/org/apache/felix/hc/core/impl/executor/HealthCheckResultCache.java
+++ b/healthcheck/core/src/main/java/org/apache/felix/hc/core/impl/executor/HealthCheckResultCache.java
@@ -72,7 +72,12 @@ public class HealthCheckResultCache {
         }
     }
 
-    /** Get the valid cache results */
+    /**
+     * Get the valid cache results for given metadata list
+     * 
+     * @param metadatas list of metadata to get results for. For each found result the metadata will be deleted
+     * @param results matching cached results are added to this list
+     */
     public void useValidCacheResults(final List<HealthCheckMetadata> metadatas,
             final Collection<HealthCheckExecutionResult> results,
             final long resultCacheTtlInMs) {

--- a/healthcheck/core/src/test/java/org/apache/felix/hc/core/impl/executor/HealthCheckResultCacheTest.java
+++ b/healthcheck/core/src/test/java/org/apache/felix/hc/core/impl/executor/HealthCheckResultCacheTest.java
@@ -22,9 +22,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,18 +30,19 @@ import java.util.List;
 
 import org.apache.felix.hc.api.HealthCheck;
 import org.apache.felix.hc.api.Result;
+import org.apache.felix.hc.api.Result.Status;
 import org.apache.felix.hc.api.ResultLog;
 import org.apache.felix.hc.api.execution.HealthCheckExecutionResult;
 import org.apache.felix.hc.api.execution.HealthCheckMetadata;
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
 
 public class HealthCheckResultCacheTest {
 
     private static final int HC_TIMEOUT_NOT_SET = -1;
+    private static final int DUR_0_MIN = 0;
     private static final int DUR_1_MIN = 60 * 1000;
     private static final int DUR_2_MIN = 2 * DUR_1_MIN;
     private static final int DUR_3_MIN = 3 * DUR_1_MIN;
@@ -52,124 +50,96 @@ public class HealthCheckResultCacheTest {
 
     private HealthCheckResultCache healthCheckResultCache = new HealthCheckResultCache();
 
-    @Mock
-    ServiceReference serviceRef;
-
-    @Before
-    public void setup() {
-        initMocks(this);
-    }
-
-    private HealthCheckMetadata setupHealthCheckMetadata(long id, long ttl) {
-        reset(serviceRef);
-        doReturn(id).when(serviceRef).getProperty(Constants.SERVICE_ID);
-        doReturn(ttl).when(serviceRef).getProperty(HealthCheck.RESULT_CACHE_TTL_IN_MS);
-        doReturn("HC id=" + id).when(serviceRef).getProperty(HealthCheck.NAME);
-        return new HealthCheckMetadata(serviceRef);
-    }
-
     @Test
     public void testHealthCheckResultCache() {
 
         HealthCheckMetadata hc1 = setupHealthCheckMetadata(1, HC_TIMEOUT_NOT_SET);
-        ExecutionResult executionResult1 = spy(new ExecutionResult(hc1, new Result(Result.Status.OK, "result for hc1"), 1));
-        doReturn(new Date(new Date().getTime() - DUR_1_MIN)).when(executionResult1).getFinishedAt();
+        ExecutionResult executionResult1 = createResult(hc1, Result.Status.OK, DUR_1_MIN);
         healthCheckResultCache.updateWith(executionResult1);
 
         HealthCheckMetadata hc2 = setupHealthCheckMetadata(2, HC_TIMEOUT_NOT_SET);
-        ExecutionResult executionResult2 = spy(new ExecutionResult(hc2, new Result(Result.Status.OK, "result for hc2"), 1));
-        doReturn(new Date(new Date().getTime() - DUR_3_MIN)).when(executionResult2).getFinishedAt();
+        ExecutionResult executionResult2 = createResult(hc2, Result.Status.OK, DUR_3_MIN);
         healthCheckResultCache.updateWith(executionResult2);
 
         HealthCheckMetadata hc3 = setupHealthCheckMetadata(3, DUR_4_MIN);
-        ExecutionResult executionResult3 = spy(new ExecutionResult(hc3, new Result(Result.Status.OK, "result for hc3"), 1));
-        doReturn(new Date(new Date().getTime() - DUR_3_MIN)).when(executionResult3).getFinishedAt();
+        ExecutionResult executionResult3 = createResult(hc3, Result.Status.OK, DUR_3_MIN);
         healthCheckResultCache.updateWith(executionResult3);
 
         HealthCheckMetadata hc4 = setupHealthCheckMetadata(4, HC_TIMEOUT_NOT_SET);
         // no result for this yet
 
-        List<HealthCheckMetadata> hcList = new ArrayList<HealthCheckMetadata>(Arrays.asList(hc1, hc2, hc3, hc4));
+        List<HealthCheckMetadata> hcList = new ArrayList<>(Arrays.asList(hc1, hc2, hc3, hc4));
         List<HealthCheckExecutionResult> results = new ArrayList<HealthCheckExecutionResult>();
 
         healthCheckResultCache.useValidCacheResults(hcList, results, DUR_2_MIN);
 
-        assertTrue(hcList.contains(hc2)); // result too old, left in hcList for later execution
-        assertTrue(hcList.contains(hc4)); // no result was added to cache via updateWith()
+        assertTrue("result too old, left in hcList for later execution", hcList.contains(hc2));
+        assertTrue("no result was added to cache via updateWith()", hcList.contains(hc4)); 
+        assertEquals("values not found in cache are left in hcList", 2, hcList.size()); 
 
-        assertTrue(results.contains(executionResult1)); // true <= result one min old, global timeout 2min
-        assertFalse(results.contains(executionResult2)); // false <= result three min old, global timeout 2min
-        assertTrue(results.contains(executionResult3)); // true <= result one three old, HC timeout 4min
-
-        // values not found in cache are left in hcList
-        assertEquals(2, hcList.size());
+        assertTrue("result one min old, global timeout 2min", results.contains(executionResult1));
+        assertFalse("result three min old, global timeout 2min", results.contains(executionResult2));
+        assertTrue("result one three old, HC timeout 4min", results.contains(executionResult3));
         assertEquals(2, results.size());
 
     }
 
     @Test
-    public void testHealthCheckResultCacheTtl() {
-
+    public void testgetValidCacheResultMissTimedout() {
         // -- test cache miss due to HC TTL
         HealthCheckMetadata hcWithTtl = setupHealthCheckMetadata(1, DUR_1_MIN);
-        ExecutionResult executionResult = spy(new ExecutionResult(hcWithTtl, new Result(Result.Status.OK, "result for hc"), 1));
-        doReturn(new Date(new Date().getTime() - DUR_2_MIN)).when(executionResult).getFinishedAt();
+        ExecutionResult executionResult = createResult(hcWithTtl, Result.Status.OK, DUR_2_MIN);
         healthCheckResultCache.updateWith(executionResult);
 
         HealthCheckExecutionResult result = healthCheckResultCache.getValidCacheResult(hcWithTtl, DUR_3_MIN);
         assertNull(result); // even though global timeout would be ok (2min<3min, the hc timeout of 1min invalidates the result)
-
+    }
+    
+    @Test
+    public void testgetValidCacheResultHitTTL() {
         // -- test cache hit due to HC TTL
-        hcWithTtl = setupHealthCheckMetadata(2, DUR_3_MIN);
-        executionResult = spy(new ExecutionResult(hcWithTtl, new Result(Result.Status.OK, "result for hc"), 1));
-        doReturn(new Date(new Date().getTime() - DUR_2_MIN)).when(executionResult).getFinishedAt();
+        HealthCheckMetadata hcWithTtl = setupHealthCheckMetadata(2, DUR_3_MIN);
+        ExecutionResult executionResult = createResult(hcWithTtl, Result.Status.OK, DUR_2_MIN);
         healthCheckResultCache.updateWith(executionResult);
 
-        result = healthCheckResultCache.getValidCacheResult(hcWithTtl, DUR_1_MIN);
+        HealthCheckExecutionResult result = healthCheckResultCache.getValidCacheResult(hcWithTtl, DUR_1_MIN);
         assertEquals(executionResult, result); // even though global timeout would invalidate this result (1min<2min, the hc timeout of 3min
                                                // allows the result)
-
+    }
+    
+    @Test
+    public void testgetValidCacheResultHitPermanent() {
         // -- test Long.MAX_VALUE
-        hcWithTtl = setupHealthCheckMetadata(3, Long.MAX_VALUE);
-        executionResult = spy(new ExecutionResult(hcWithTtl, new Result(Result.Status.OK, "result for hc"), 1));
-        doReturn(new Date(new Date().getTime() - DUR_4_MIN)).when(executionResult).getFinishedAt();
+        HealthCheckMetadata hcWithTtl = setupHealthCheckMetadata(3, Long.MAX_VALUE);
+        ExecutionResult executionResult = createResult(hcWithTtl, Result.Status.OK, DUR_4_MIN);
         healthCheckResultCache.updateWith(executionResult);
 
-        result = healthCheckResultCache.getValidCacheResult(hcWithTtl, DUR_1_MIN);
+        HealthCheckExecutionResult result = healthCheckResultCache.getValidCacheResult(hcWithTtl, DUR_1_MIN);
         assertEquals(executionResult, result);
-
-    }
-
-    private HealthCheckMetadata setupHealthCheckMetadataWithStickyResults(long id, long nonOkStickyForSec) {
-        reset(serviceRef);
-        doReturn(id).when(serviceRef).getProperty(Constants.SERVICE_ID);
-        doReturn(nonOkStickyForSec).when(serviceRef).getProperty(HealthCheck.KEEP_NON_OK_RESULTS_STICKY_FOR_SEC);
-        doReturn("HC id=" + id).when(serviceRef).getProperty(HealthCheck.NAME);
-        return new HealthCheckMetadata(serviceRef);
     }
 
     @Test
     public void testCreateExecutionResultWithStickyResults() {
 
         HealthCheckMetadata hcWithStickyResultsSet = setupHealthCheckMetadataWithStickyResults(1, 120 /* 2 minutes */);
-        ExecutionResult currentResult = spy(new ExecutionResult(hcWithStickyResultsSet, new Result(Result.Status.OK, "result for hc"), 1));
+        ExecutionResult currentResult = createResult(hcWithStickyResultsSet, Result.Status.OK, DUR_0_MIN);
         HealthCheckExecutionResult overallResultWithStickyResults = healthCheckResultCache
                 .createExecutionResultWithStickyResults(currentResult);
         assertTrue("Exact same result is expected if no history exists", currentResult == overallResultWithStickyResults);
 
         // add 4 minutes old WARN to cache
-        ExecutionResult oldWarnResult = spy(
-                new ExecutionResult(hcWithStickyResultsSet, new Result(Result.Status.WARN, "result for hc"), 1));
-        doReturn(new Date(System.currentTimeMillis() - DUR_4_MIN)).when(oldWarnResult).getFinishedAt();
+        ExecutionResult oldWarnResult = createResult(hcWithStickyResultsSet, Result.Status.WARN, DUR_4_MIN);
         healthCheckResultCache.updateWith(oldWarnResult);
 
         // check that it is not used
-        currentResult = new ExecutionResult(hcWithStickyResultsSet, new Result(Result.Status.OK, "result for hc"), 1);
+        currentResult = createResult(hcWithStickyResultsSet, Result.Status.OK, DUR_0_MIN);
         overallResultWithStickyResults = healthCheckResultCache.createExecutionResultWithStickyResults(currentResult);
         assertTrue("Exact same result is expected if WARN HC Result is too old", currentResult == overallResultWithStickyResults);
 
         // change WARN to 1 minute age
-        doReturn(new Date(System.currentTimeMillis() - DUR_1_MIN)).when(oldWarnResult).getFinishedAt();
+        ExecutionResult warnResult = createResult(hcWithStickyResultsSet, Result.Status.WARN, DUR_1_MIN);
+        healthCheckResultCache.updateWith(warnResult);
+
         overallResultWithStickyResults = healthCheckResultCache.createExecutionResultWithStickyResults(currentResult);
         assertTrue("Expect newly created result as sticky result should be taken into account",
                 currentResult != overallResultWithStickyResults);
@@ -178,9 +148,7 @@ public class HealthCheckResultCacheTest {
         assertEquals("Expect 4 entries, two each for current and WARN", 4, getLogMsgCount(overallResultWithStickyResults));
 
         // add 1 minutes old CRITICAL to cache
-        ExecutionResult oldCriticalResult = spy(
-                new ExecutionResult(hcWithStickyResultsSet, new Result(Result.Status.CRITICAL, "result for hc"), 1));
-        doReturn(new Date(System.currentTimeMillis() - DUR_1_MIN)).when(oldCriticalResult).getFinishedAt();
+        ExecutionResult oldCriticalResult = createResult(hcWithStickyResultsSet, Result.Status.CRITICAL, DUR_1_MIN);
         healthCheckResultCache.updateWith(oldCriticalResult);
 
         overallResultWithStickyResults = healthCheckResultCache.createExecutionResultWithStickyResults(currentResult);
@@ -193,6 +161,28 @@ public class HealthCheckResultCacheTest {
 
     }
 
+    private ExecutionResult createResult(HealthCheckMetadata hc, Status status, int minutesAgo) {
+        Date finishedAt = new Date(new Date().getTime() - minutesAgo);
+        return new ExecutionResult(hc, new Result(status, "result for hc"), finishedAt, 1, false);
+    }
+
+    private HealthCheckMetadata setupHealthCheckMetadata(long id, long ttl) {
+        ServiceReference<?> serviceRef = Mockito.mock(ServiceReference.class);
+        doReturn(id).when(serviceRef).getProperty(Constants.SERVICE_ID);
+        doReturn(ttl).when(serviceRef).getProperty(HealthCheck.RESULT_CACHE_TTL_IN_MS);
+        doReturn("HC id=" + id).when(serviceRef).getProperty(HealthCheck.NAME);
+        return new HealthCheckMetadata(serviceRef);
+    }
+
+    private HealthCheckMetadata setupHealthCheckMetadataWithStickyResults(long id, long nonOkStickyForSec) {
+        ServiceReference<?> serviceRef = Mockito.mock(ServiceReference.class);
+        doReturn(id).when(serviceRef).getProperty(Constants.SERVICE_ID);
+        doReturn(nonOkStickyForSec).when(serviceRef).getProperty(HealthCheck.KEEP_NON_OK_RESULTS_STICKY_FOR_SEC);
+        doReturn("HC id=" + id).when(serviceRef).getProperty(HealthCheck.NAME);
+        return new HealthCheckMetadata(serviceRef);
+    }
+
+    @SuppressWarnings("unused")
     private int getLogMsgCount(HealthCheckExecutionResult result) {
         int count = 0;
         for (ResultLog.Entry entry : result.getHealthCheckResult()) {


### PR DESCRIPTION
Use alternative constructor instead of spy.
Use local mock of  Servicereference.