### PR TITLE
[FELIX-6493] Extend is-up-to-date logic of Manifest goal

### DIFF
--- a/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/ManifestPlugin.java
+++ b/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/ManifestPlugin.java
@@ -103,13 +103,17 @@ public class ManifestPlugin extends BundlePlugin
     protected void execute( Map<String, String> instructions, ClassPathItem[] classpath )
         throws MojoExecutionException
     {
+        File outputFile = new File( manifestLocation, "MANIFEST.MF" );
+        boolean metadataUpToDate = isMetadataUpToDate(outputFile, project);
 
-        if (supportIncrementalBuild && isUpToDate(project)) {
+        if (supportIncrementalBuild && metadataUpToDate && isUpToDate(project)) {
             return;
         }
         // in incremental build execute manifest generation only when explicitly activated
         // and when any java file was touched since last build
-        if (buildContext.isIncremental() && !(supportIncrementalBuild && anyJavaSourceFileTouchedSinceLastBuild())) {
+        if (buildContext.isIncremental() && (!supportIncrementalBuild //
+            || (metadataUpToDate && !anyJavaSourceFileTouchedSinceLastBuild())))
+        {
             getLog().debug("Skipping manifest generation because no java source file was added, updated or removed since last build.");
             return;
         }
@@ -118,10 +122,6 @@ public class ManifestPlugin extends BundlePlugin
         try
         {
             analyzer = getAnalyzer(project, instructions, classpath);
-
-            if (supportIncrementalBuild) {
-                writeIncrementalInfo(project);
-            }
         }
         catch ( FileNotFoundException e )
         {
@@ -143,11 +143,13 @@ public class ManifestPlugin extends BundlePlugin
             throw new MojoExecutionException( "Internal error in maven-bundle-plugin", e );
         }
 
-        File outputFile = new File( manifestLocation, "MANIFEST.MF" );
-
         try
         {
             writeManifest( analyzer, outputFile, niceManifest, exportScr, scrLocation, buildContext, getLog() );
+
+            if (supportIncrementalBuild) {
+                writeIncrementalInfo(project);
+            }
         }
         catch ( Exception e )
         {
@@ -364,7 +366,7 @@ public class ManifestPlugin extends BundlePlugin
                 w.append(curdata);
             }
         } catch (IOException e) {
-            throw new MojoExecutionException("Error checking manifest uptodate status", e);
+            throw getManifestUptodateCheckException(e);
         }
     }
 
@@ -379,7 +381,7 @@ public class ManifestPlugin extends BundlePlugin
             }
             String curdata = getIncrementalData();
             if (curdata.equals(prvdata)) {
-                long lastmod = Files.getLastModifiedTime(cacheData).toMillis();
+                long lastmod = lastModified(cacheData);
                 Set<String> stale = Stream.concat(Stream.of(new File(project.getBuild().getOutputDirectory())),
                                                             project.getArtifacts().stream().map(Artifact::getFile))
                         .flatMap(f -> newer(lastmod, f))
@@ -404,9 +406,43 @@ public class ManifestPlugin extends BundlePlugin
                 }
             }
         } catch (IOException e) {
-            throw new MojoExecutionException("Error checking manifest uptodate status", e);
+            throw getManifestUptodateCheckException(e);
         }
         return false;
+    }
+
+    private boolean isMetadataUpToDate(File outputFile, MavenProject project)
+        throws MojoExecutionException
+    {
+        if (!outputFile.isFile()) // does MANIFEST.MF exist?
+        {
+            getLog().info("No MANIFEST.MF file found, generating manifest.");
+            return false;
+        }
+        try
+        { // is pom.xml up-to-date?
+            Path cacheData = getIncrementalDataPath(project);
+            long manifestLastModified = lastModified(cacheData);
+            while (project != null)
+            {
+                Path pom = project.getFile().toPath();
+                if (manifestLastModified < lastModified(pom))
+                {
+                    return false;
+                }
+                project = project.getParent();
+            }
+        }
+        catch (IOException e)
+        {
+            throw getManifestUptodateCheckException(e);
+        }
+        return true;
+    }
+
+    private static MojoExecutionException getManifestUptodateCheckException(IOException e)
+    {
+        return new MojoExecutionException("Error checking manifest uptodate status", e);
     }
 
     private String getIncrementalData() {
@@ -421,10 +457,15 @@ public class ManifestPlugin extends BundlePlugin
 
     private long lastmod(Path p) {
         try {
-            return Files.getLastModifiedTime(p).toMillis();
+            return lastModified(p);
         } catch (IOException e) {
             return 0;
         }
+    }
+
+    private static long lastModified(Path p) throws IOException
+    {
+        return Files.getLastModifiedTime(p).toMillis();
     }
 
     private Stream<String> newer(long lastmod, File file) {


### PR DESCRIPTION
This PR addresses issue [FELIX-6493](https://issues.apache.org/jira/browse/FELIX-6493) and extends the is-up-to-date logic of the Manifest goal to
- consider as not up-to-date if the MANIFEST.MF file to generate does not exist
- consider pom.xml modifications in up-to-date logic
- write incremental-info after manifest to not self-cause out-of-date