### PR TITLE
Migrate ipojo to 11 jdk

### DIFF
--- a/ipojo/manipulator/annotations/pom.xml
+++ b/ipojo/manipulator/annotations/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.apache.felix.ipojo.annotations</artifactId>
-    <version>1.12.3</version>
+    <version>1.13.0-SNAPSHOT</version>
     <name>Apache Felix iPOJO Annotations</name>
 
     <description>

--- a/ipojo/manipulator/annotations/pom.xml
+++ b/ipojo/manipulator/annotations/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.apache.felix.ipojo.annotations</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.12.3</version>
     <name>Apache Felix iPOJO Annotations</name>
 
     <description>
@@ -42,8 +42,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/ipojo/manipulator/bnd-ipojo-plugin/pom.xml
+++ b/ipojo/manipulator/bnd-ipojo-plugin/pom.xml
@@ -71,8 +71,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
 

--- a/ipojo/manipulator/manipulator-bom/pom.xml
+++ b/ipojo/manipulator/manipulator-bom/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>ipojo-manipulator-bom</artifactId>
-    <version>1.12.3</version>
+  <version>1.13.0-SNAPSHOT</version>
   <name>Apache Felix iPOJO Manipulator BOM</name>
   <packaging>pom</packaging>
 

--- a/ipojo/manipulator/manipulator-bom/pom.xml
+++ b/ipojo/manipulator/manipulator-bom/pom.xml
@@ -28,12 +28,12 @@
   </parent>
 
   <artifactId>ipojo-manipulator-bom</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.12.3</version>
   <name>Apache Felix iPOJO Manipulator BOM</name>
   <packaging>pom</packaging>
 
   <properties>
-    <asm.version>5.0.2</asm.version>
+    <asm.version>7.0</asm.version>
     <metadata.version>1.6.0</metadata.version>
   </properties>
 

--- a/ipojo/manipulator/manipulator/pom.xml
+++ b/ipojo/manipulator/manipulator/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
     <artifactId>org.apache.felix.ipojo.manipulator</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.12.3</version>
     <name>Apache Felix iPOJO Manipulator</name>
 
     <description>
@@ -40,8 +40,23 @@
     <dependencies>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
-            <version>5.0.2</version>
+            <artifactId>asm</artifactId>
+            <version>7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-tree</artifactId>
+            <version>7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <version>7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+            <version>7.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
@@ -97,7 +112,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>5.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -131,8 +146,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
 
@@ -160,7 +175,11 @@
                     </excludes>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/ipojo/manipulator/manipulator/pom.xml
+++ b/ipojo/manipulator/manipulator/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
     <artifactId>org.apache.felix.ipojo.manipulator</artifactId>
-    <version>1.12.3</version>
+    <version>1.13.0-SNAPSHOT</version>
     <name>Apache Felix iPOJO Manipulator</name>
 
     <description>

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ClassChecker.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ClassChecker.java
@@ -47,6 +47,11 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
     private Map<String, String> m_fields = new TreeMap<String, String>();
 
     /**
+     * Collection of final fields
+     */
+    private Set<String> m_finalFields=new HashSet<>();
+
+    /**
      * Method List of method descriptor discovered in the component class.
      */
     private List<MethodDescriptor> m_methods = new ArrayList<MethodDescriptor>();
@@ -73,7 +78,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
     private int m_classVersion;
 
     public ClassChecker() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     /**
@@ -116,6 +121,9 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
             }
         } else {
             m_fields.put(name, type.getClassName());
+        }
+        if ((access & ACC_FINAL) == ACC_FINAL) {
+            m_finalFields.add(name);
         }
 
         return null;
@@ -300,6 +308,9 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
         return m_fields;
     }
 
+    public Set<String> getFinalFields(){
+        return m_finalFields;
+    }
     /**
      * Get collected methods.
      *
@@ -345,7 +356,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
          * @param md the method descriptor of the visited method.
          */
         private MethodInfoCollector(MethodDescriptor md) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
             m_method = md;
         }
 
@@ -386,7 +397,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
                 m_method.addParameterAnnotation(id, ann);
                 return ann;
             }
-            
+
             /*
              * It is harmless to keep injected parameter annotations on original constructor
              * for correct property resolution in case of re-manipulation
@@ -456,7 +467,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
          * @param visible the visibility of the annotation at runtime
          */
         public AnnotationDescriptor(String name, boolean visible) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
             m_name = name;
             m_visible = visible;
         }
@@ -469,7 +480,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
          * @param desc the descriptor of the annotation
          */
         public AnnotationDescriptor(String name, String desc) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
             m_name = name;
             m_visible = true;
             m_desc = desc;
@@ -641,7 +652,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
          * @param name the name of the attribute.
          */
         public ArrayAttribute(String name) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
             m_name = name;
         }
 
@@ -833,7 +844,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
     private class InnerClassAssignedToStaticFieldDetector extends MethodVisitor {
 
         public InnerClassAssignedToStaticFieldDetector() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
         }
 
         @Override

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ClassManipulator.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ClassManipulator.java
@@ -286,7 +286,7 @@ public class ClassManipulator extends ClassVisitor implements Opcodes {
 
                 // Generates setter method
                 String sDesc = "(" + desc + ")V";
-                createArraySetter(name, sDesc);
+                createArraySetter(access, name, sDesc);
 
             } else {
                 // Generate the getter method
@@ -784,13 +784,14 @@ public class ClassManipulator extends ClassVisitor implements Opcodes {
 
     /**
      * Create a getter method for an array.
+     * @param access
      * @param name : field name
      * @param desc : method description
      */
-    private void createArraySetter(String name, String desc) {
+    private void createArraySetter(int access, String name, String desc) {
         MethodVisitor mv = cv.visitMethod(0, "__set" + name, desc, null, null);
         mv.visitCode();
-
+        boolean isFinal = (access & ACC_FINAL) == ACC_FINAL;
         String internalType = desc.substring(1);
         internalType = internalType.substring(0, internalType.length() - 2);
 
@@ -801,9 +802,11 @@ public class ClassManipulator extends ClassVisitor implements Opcodes {
         Label l2 = new Label();
         mv.visitJumpInsn(IFNE, l2);
 
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitVarInsn(ALOAD, 1);
-        mv.visitFieldInsn(PUTFIELD, m_owner, name, internalType);
+        if(!isFinal) {
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitVarInsn(ALOAD, 1);
+            mv.visitFieldInsn(PUTFIELD, m_owner, name, internalType);
+        }
         mv.visitInsn(RETURN);
         mv.visitLabel(l2);
 

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/InnerClassAdapter.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/InnerClassAdapter.java
@@ -72,7 +72,7 @@ public class InnerClassAdapter extends ClassVisitor implements Opcodes {
      */
     public InnerClassAdapter(String name, ClassVisitor visitor, String outerClassName,
                              Manipulator manipulator) {
-        super(Opcodes.ASM5, visitor);
+        super(Opcodes.ASM7, visitor);
         m_name = name;
         m_simpleName = m_name.substring(m_name.indexOf("$") + 1);
         m_outer = outerClassName;

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/InnerClassChecker.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/InnerClassChecker.java
@@ -34,7 +34,7 @@ public class InnerClassChecker extends ClassVisitor implements Opcodes {
     private final Manipulator m_manipulator;
 
     public InnerClassChecker(String name, Manipulator manipulator) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         m_name = name;
         m_manipulator = manipulator;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/Manipulator.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/Manipulator.java
@@ -47,6 +47,11 @@ public class Manipulator {
     private Map<String, String> m_fields;
 
     /**
+     * Store th visited final fields
+     */
+    private Set<String> m_finalFields;
+
+    /**
      * Store the interface implemented by the class.
      */
     private List<String> m_interfaces;
@@ -101,6 +106,7 @@ public class Manipulator {
         is.close();
 
         m_fields = ck.getFields(); // Get visited fields (contains only POJO fields)
+        m_finalFields = ck.getFinalFields();
         m_className = ck.getClassName();
 
         // Get interfaces and super class.
@@ -217,6 +223,10 @@ public class Manipulator {
 
     public Map<String, String> getFields() {
         return m_fields;
+    }
+
+    public Set<String> getFinalFields(){
+        return m_finalFields;
     }
 
     public List<MethodDescriptor> getMethods() {

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/MethodCodeAdapter.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/MethodCodeAdapter.java
@@ -53,7 +53,7 @@ public class MethodCodeAdapter extends GeneratorAdapter implements Opcodes {
      * @param fields : Contained fields
      */
     public MethodCodeAdapter(final MethodVisitor mv, final String owner, int access, String name, String desc, Set<String> fields) {
-        super(Opcodes.ASM5, mv, access, name, desc);
+        super(Opcodes.ASM7, mv, access, name, desc);
         m_owner = owner;
         m_fields = fields;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/ClassMetadataCollector.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/ClassMetadataCollector.java
@@ -58,7 +58,7 @@ public class ClassMetadataCollector extends ClassVisitor {
     private Element instanceMetadata;
 
     public ClassMetadataCollector(BindingRegistry registry, Reporter reporter) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.registry = registry;
         this.reporter = reporter;
         node = new ClassNode();

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/FieldMetadataCollector.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/FieldMetadataCollector.java
@@ -46,7 +46,7 @@ public class FieldMetadataCollector extends FieldVisitor {
     private FieldNode node;
 
     public FieldMetadataCollector(ComponentWorkbench workbench, FieldNode node) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.node = node;
         this.registry = workbench.getBindingRegistry();

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/MethodMetadataCollector.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/MethodMetadataCollector.java
@@ -47,7 +47,7 @@ public class MethodMetadataCollector extends MethodVisitor {
     private MethodNode node;
 
     public MethodMetadataCollector(ComponentWorkbench workbench, MethodNode node, Reporter reporter) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.node = node;
         this.registry = workbench.getBindingRegistry();

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/discovery/HandlerBindingDiscovery.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/discovery/HandlerBindingDiscovery.java
@@ -41,7 +41,7 @@ public class HandlerBindingDiscovery extends AnnotationVisitor implements Annota
      * Constructs a new {@link org.objectweb.asm.AnnotationVisitor}.
      */
     public HandlerBindingDiscovery() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     public AnnotationVisitor visitAnnotation(final String desc) {

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/parser/AnnotationTypeVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/parser/AnnotationTypeVisitor.java
@@ -34,7 +34,7 @@ public class AnnotationTypeVisitor extends ClassVisitor {
     private AnnotationType annotationType;
 
     public AnnotationTypeVisitor() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     @Override

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/parser/replay/AnnotationRecorder.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/parser/replay/AnnotationRecorder.java
@@ -33,7 +33,7 @@ public class AnnotationRecorder extends AnnotationVisitor implements Replay {
     private List<Replay> m_replays = new ArrayList<Replay>();
 
     public AnnotationRecorder() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     public void visit(final String name, final Object value) {

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ComponentVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ComponentVisitor.java
@@ -45,7 +45,7 @@ public class ComponentVisitor extends AnnotationVisitor {
     private ComponentWorkbench workbench;
 
     public ComponentVisitor(ComponentWorkbench workbench, Reporter reporter) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.reporter = reporter;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ControllerVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ControllerVisitor.java
@@ -37,7 +37,7 @@ public class ControllerVisitor extends AnnotationVisitor {
     private String field;
 
     public ControllerVisitor(ComponentWorkbench workbench, String field) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.field = field;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/FieldPropertyVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/FieldPropertyVisitor.java
@@ -82,7 +82,7 @@ public class FieldPropertyVisitor extends AnnotationVisitor {
      * @param field : field name.
      */
     public FieldPropertyVisitor(String field, Element parent) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         m_parent = parent;
         m_field = field;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/HandlerDeclarationVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/HandlerDeclarationVisitor.java
@@ -53,7 +53,7 @@ public class HandlerDeclarationVisitor extends AnnotationVisitor {
     private Reporter reporter;
 
     public HandlerDeclarationVisitor(ComponentWorkbench workbench, DocumentBuilder builder, Reporter reporter) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.builder = builder;
         this.reporter = reporter;

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/HandlerVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/HandlerVisitor.java
@@ -41,7 +41,7 @@ public class HandlerVisitor extends AnnotationVisitor {
     private Reporter reporter;
 
     public HandlerVisitor(ComponentWorkbench workbench, Reporter reporter) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.reporter = reporter;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/InstantiateVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/InstantiateVisitor.java
@@ -38,7 +38,7 @@ public class InstantiateVisitor extends AnnotationVisitor {
     private ComponentWorkbench workbench;
 
     public InstantiateVisitor(ComponentWorkbench workbench) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
     }
 

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/LifecycleVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/LifecycleVisitor.java
@@ -42,7 +42,7 @@ public class LifecycleVisitor extends AnnotationVisitor {
     private Transition transition;
 
     public LifecycleVisitor(ComponentWorkbench workbench, String name, Transition transition) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.name = name;
         this.transition = transition;

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/MethodPropertyVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/MethodPropertyVisitor.java
@@ -73,7 +73,7 @@ public class MethodPropertyVisitor extends AnnotationVisitor {
      * @param method : attached method.
      */
     public MethodPropertyVisitor(Element parent, String method) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         m_parent = parent;
         m_method = method;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/PostRegistrationVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/PostRegistrationVisitor.java
@@ -35,7 +35,7 @@ public class PostRegistrationVisitor extends AnnotationVisitor {
     private String name;
 
     public PostRegistrationVisitor(ComponentWorkbench workbench, String name) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.name = name;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/PostUnregistrationVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/PostUnregistrationVisitor.java
@@ -35,7 +35,7 @@ public class PostUnregistrationVisitor extends AnnotationVisitor {
     private String name;
 
     public PostUnregistrationVisitor(ComponentWorkbench workbench, String name) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.name = name;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ProvidesVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ProvidesVisitor.java
@@ -42,7 +42,7 @@ public class ProvidesVisitor extends AnnotationVisitor {
     private Element m_prov = new Element("provides", "");
 
     public ProvidesVisitor(ComponentWorkbench workbench) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
     }
 
@@ -75,7 +75,7 @@ public class ProvidesVisitor extends AnnotationVisitor {
         } else if (name.equals("properties")) {
             // Create a new simple visitor to visit the nested ServiceProperty annotations
             // Collected properties are collected in m_prov
-            return new AnnotationVisitor(Opcodes.ASM5) {
+            return new AnnotationVisitor(Opcodes.ASM7) {
                 public AnnotationVisitor visitAnnotation(String ignored, String desc) {
                     return new FieldPropertyVisitor(m_prov);
                 }
@@ -104,7 +104,7 @@ public class ProvidesVisitor extends AnnotationVisitor {
 
 
         public InterfaceArrayVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
         }
 
         /**

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/RequiresVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/RequiresVisitor.java
@@ -106,7 +106,7 @@ public class RequiresVisitor extends AnnotationVisitor {
      * @param name : field name.
      */
     public RequiresVisitor(ComponentWorkbench workbench, String name) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.m_field = name;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ServiceControllerVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ServiceControllerVisitor.java
@@ -48,7 +48,7 @@ public class ServiceControllerVisitor extends AnnotationVisitor {
      * @param field : field name.
      */
     public ServiceControllerVisitor(String field, Element provides) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.provides = provides;
         controller.addAttribute(new Attribute("field", field));
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/UpdatedVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/UpdatedVisitor.java
@@ -36,7 +36,7 @@ public class UpdatedVisitor extends AnnotationVisitor {
     private String name;
 
     public UpdatedVisitor(ComponentWorkbench workbench, String name) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.name = name;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/bind/AbstractBindVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/bind/AbstractBindVisitor.java
@@ -36,7 +36,7 @@ public abstract class AbstractBindVisitor extends AnnotationVisitor {
     protected Action action;
 
     public AbstractBindVisitor(ComponentWorkbench workbench, Action action) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.action = action;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/generic/GenericVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/generic/GenericVisitor.java
@@ -35,7 +35,7 @@ public class GenericVisitor extends AnnotationVisitor {
     protected Element element;
 
     public GenericVisitor(Element element) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.element = element;
     }
 

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/generic/SubArrayVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/generic/SubArrayVisitor.java
@@ -54,7 +54,7 @@ public class SubArrayVisitor extends AnnotationVisitor {
      * @param name : attribute name.
      */
     public SubArrayVisitor(Element elem, String name) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         m_elem = elem;
         m_name = name;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/FieldStereotypeVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/FieldStereotypeVisitor.java
@@ -34,7 +34,7 @@ public class FieldStereotypeVisitor extends AnnotationVisitor {
     private final AnnotationType m_annotationType;
 
     public FieldStereotypeVisitor(final FieldVisitor delegate, AnnotationType annotationType) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.m_delegate = delegate;
         m_annotationType = annotationType;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/MethodStereotypeVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/MethodStereotypeVisitor.java
@@ -34,7 +34,7 @@ public class MethodStereotypeVisitor extends AnnotationVisitor {
     private final AnnotationType m_annotationType;
 
     public MethodStereotypeVisitor(final MethodVisitor delegate, AnnotationType annotationType) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.m_delegate = delegate;
         m_annotationType = annotationType;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/ParameterStereotypeVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/ParameterStereotypeVisitor.java
@@ -37,7 +37,7 @@ public class ParameterStereotypeVisitor extends AnnotationVisitor {
     private final AnnotationType m_annotationType;
 
     public ParameterStereotypeVisitor(final MethodVisitor delegate, final int index, AnnotationType annotationType) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.m_delegate = delegate;
         this.index = index;
         m_annotationType = annotationType;

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/TypeStereotypeVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/TypeStereotypeVisitor.java
@@ -36,7 +36,7 @@ public class TypeStereotypeVisitor extends AnnotationVisitor {
     private final AnnotationType m_annotationType;
 
     public TypeStereotypeVisitor(final ClassVisitor delegate, AnnotationType annotationType) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.m_delegate = delegate;
         m_annotationType = annotationType;
     }

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/util/ChainedAnnotationVisitor.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/util/ChainedAnnotationVisitor.java
@@ -35,7 +35,7 @@ public class ChainedAnnotationVisitor extends AnnotationVisitor {
     private List<AnnotationVisitor> m_visitors = new ArrayList<AnnotationVisitor>();
 
     public ChainedAnnotationVisitor() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     public List<AnnotationVisitor> getVisitors() {

--- a/ipojo/manipulator/manipulator/src/test/java/org/apache/felix/ipojo/manipulation/ClassCheckerTestCase.java
+++ b/ipojo/manipulator/manipulator/src/test/java/org/apache/felix/ipojo/manipulation/ClassCheckerTestCase.java
@@ -91,7 +91,7 @@ public class ClassCheckerTestCase extends TestCase {
         assertEquals(1, annotations.size());
         ClassChecker.AnnotationDescriptor annotationDescriptor = annotations.get(0);
         MethodVisitor mv = mock(MethodVisitor.class);
-        when(mv.visitAnnotation(desc, true)).thenReturn(new AnnotationVisitor(Opcodes.ASM5) {});
+        when(mv.visitAnnotation(desc, true)).thenReturn(new AnnotationVisitor(Opcodes.ASM7) {});
         annotationDescriptor.visitAnnotation(mv);
     }
 

--- a/ipojo/manipulator/manipulator/src/test/java/test/InterfaceWithStatic.java
+++ b/ipojo/manipulator/manipulator/src/test/java/test/InterfaceWithStatic.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test;
+
+public interface InterfaceWithStatic {
+    static InterfaceWithStatic ofString(String string) {
+        return new InterfaceWithStatic() {
+            @Override
+            public String getString() {
+                return string;
+            }
+        };
+    }
+
+    String getString();
+}

--- a/ipojo/manipulator/manipulator/src/test/java/test/PojoWithFinalArray.java
+++ b/ipojo/manipulator/manipulator/src/test/java/test/PojoWithFinalArray.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test;
+
+public class PojoWithFinalArray {
+
+    private final String[] strings = createInterfaces();
+
+    private String[] createInterfaces() {
+        return new String[]{"test"};
+    }
+
+    public String doSomething() {
+        return strings[0];
+    }
+
+}

--- a/ipojo/manipulator/manipulator/src/test/java/test/PojoWithStaticInterface.java
+++ b/ipojo/manipulator/manipulator/src/test/java/test/PojoWithStaticInterface.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test;
+
+public class PojoWithStaticInterface {
+
+    private final InterfaceWithStatic intf = InterfaceWithStatic.ofString("test");
+
+    // This is a simple POJO
+
+    public String doSomething() {
+        return intf.getString();
+    }
+
+}

--- a/ipojo/manipulator/manipulator/src/test/java/test/frames/CryptoServiceSingleton.java
+++ b/ipojo/manipulator/manipulator/src/test/java/test/frames/CryptoServiceSingleton.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -57,6 +57,7 @@ public class CryptoServiceSingleton {
     private Hash defaultHash;
 
     private final String secret;
+    private final String testField = "TEST";
 
     public CryptoServiceSingleton(String secret, Hash defaultHash,
                                   Integer keySize, Integer iterationCount) {

--- a/ipojo/manipulator/maven-ipojo-plugin/pom.xml
+++ b/ipojo/manipulator/maven-ipojo-plugin/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>maven-ipojo-plugin</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.12.3</version>
     <name>Apache Felix iPOJO Maven Plugin</name>
     <packaging>maven-plugin</packaging>
 
@@ -102,8 +102,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
 
@@ -129,6 +129,11 @@
                         <exclude>src/main/resources/archetype-resources/**</exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </build>

--- a/ipojo/manipulator/maven-ipojo-plugin/pom.xml
+++ b/ipojo/manipulator/maven-ipojo-plugin/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>maven-ipojo-plugin</artifactId>
-    <version>1.12.3</version>
+    <version>1.13.0-SNAPSHOT</version>
     <name>Apache Felix iPOJO Maven Plugin</name>
     <packaging>maven-plugin</packaging>
 

--- a/ipojo/metadata/pom.xml
+++ b/ipojo/metadata/pom.xml
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>5.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -58,8 +58,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <target>1.5</target>
-                    <source>1.5</source>
+                    <target>11</target>
+                    <source>11</source>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
There were solved several problems:

1. Using ASM5 - was increased to ASM7 for compiling in java 11+. For this change was removed `asm-all` dependency and used concrete dependencies
2. There was a problem on initializing final fields. iPOJO manipulator changed all class fields in constructor to initialize through setters invoking. And this was a problem because such possibility was fixed in java 9 ([Compilers accept modification of final fields outside initializer methods](https://bugs.openjdk.java.net/browse/JDK-8157181)). Besides there is no need to change final fields initialization, because after manipulator processing they are always accessed through getters
3. Was fixed static interface initialization

I had to change version to 1.13.0 line cause my own usage, i think it's good to change minor version if PR will be accepted