### PR TITLE
[FELIX-6494] upgrade bndlib from 5.1.1 to 6.2.0

### DIFF
--- a/tools/maven-bundle-plugin/pom.xml
+++ b/tools/maven-bundle-plugin/pom.xml
@@ -68,7 +68,7 @@
     <plugin>
      <groupId>org.apache.maven.plugins</groupId>
      <artifactId>maven-plugin-plugin</artifactId>
-     <version>3.6.1</version>
+     <version>3.6.4</version>
      <executions>
       <execution>
        <id>default-descriptor</id>
@@ -172,7 +172,7 @@
   <dependency>
     <groupId>biz.aQute.bnd</groupId>
     <artifactId>biz.aQute.bndlib</artifactId>
-    <version>5.1.1</version>
+    <version>6.2.0</version>
   </dependency>
   <dependency>
     <groupId>org.slf4j</groupId>
@@ -207,7 +207,7 @@
   <dependency>
    <groupId>org.apache.maven</groupId>
    <artifactId>maven-archiver</artifactId>
-   <version>3.5.0</version>
+   <version>3.5.2</version>
   </dependency>
   <dependency>
    <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FELIX-6496
non-reproducible order of Exports/Imports https://github.com/bndtools/bnd/issues/5021 has been fixed