### PR TITLE
FELIX-6511: Cancel the SCR Component Registry's changeCountTimer on deactivation.

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/Activator.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/Activator.java
@@ -407,6 +407,7 @@ public class Activator extends AbstractExtender
         // dispose component registry
         if ( m_componentRegistry != null )
         {
+            m_componentRegistry.shutdown();
             m_componentRegistry = null;
         }
 

--- a/scr/src/main/java/org/apache/felix/scr/impl/ComponentRegistry.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/ComponentRegistry.java
@@ -732,7 +732,7 @@ public class ComponentRegistry
             final Timer timer;
             synchronized ( this.changeCountTimerLock ) {
                 if ( this.changeCountTimer == null ) {
-                    this.changeCountTimer = new Timer();
+                    this.changeCountTimer = new Timer("SCR Component Registry", true);
                 }
                 timer = this.changeCountTimer;
             }
@@ -772,6 +772,13 @@ public class ComponentRegistry
                     "Service changecount Timer for {0} had a problem", e,
                     registration.getReference());
             }
+        }
+    }
+
+    public void shutdown() {
+        final Timer timer = changeCountTimer;
+        if (timer != null) {
+            timer.cancel();
         }
     }
 }


### PR DESCRIPTION
Cancel the `changeCountTimer`. Also name its thread "SCR Component Registry" rather than leaving it as "Timer-0".