### PR TITLE
FELIX-6521 - Stop exporting org.osgi.service.component packages

### DIFF
--- a/scr/bnd.bnd
+++ b/scr/bnd.bnd
@@ -14,10 +14,7 @@ Require-Capability: osgi.ee;\
                    filter:="(|(&(osgi.ee=JavaSE)(version=1.7))(&(osgi.ee=JavaSE/compact1)(version=1.8)))"
 
 Export-Package: org.apache.felix.scr.component;version=1.1.0;provide:=true, \
- org.apache.felix.scr.info;version=1.0.0;provide:=true, \
- org.osgi.service.component;version=1.5;provide:=true, \
- org.osgi.service.component.runtime;version=1.5;provide:=true, \
- org.osgi.service.component.runtime.dto;version=1.5;provide:=true
+ org.apache.felix.scr.info;version=1.0.0;provide:=true
 
 Private-Package: org.apache.felix.scr.impl.*
 

--- a/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
@@ -190,6 +190,7 @@ public abstract class ComponentTestBase
                         mavenBundle( "org.apache.felix", "org.apache.felix.configadmin", felixCaVersion ) ),
                         mavenBundle( "org.osgi", "org.osgi.util.promise"),
                         mavenBundle( "org.osgi", "org.osgi.util.function"),
+                        mavenBundle( "org.osgi", "org.osgi.service.component"),
                         mavenBundle( "org.ops4j.pax.url", "pax-url-aether"),
                 junitBundles(), frameworkProperty( "org.osgi.framework.bsnversion" ).value( bsnVersionUniqueness ),
                 systemProperty( "ds.factory.enabled" ).value( Boolean.toString( NONSTANDARD_COMPONENT_FACTORY_BEHAVIOR ) ),


### PR DESCRIPTION
Require the spec package `org.osgi.service.component` and its subpackages to be imported.