### PR TITLE
FELIX-6526|FELIX-6527 Handle absent incremental manifest data file

### DIFF
--- a/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/ManifestPlugin.java
+++ b/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/ManifestPlugin.java
@@ -424,8 +424,12 @@ public class ManifestPlugin extends BundlePlugin
             return false;
         }
         try
-        { // is pom.xml up-to-date?
+        { // has this project's or a parent's pom.xml been modified after the manifest was
+            // generated last?
             Path cacheData = getIncrementalDataPath(project);
+            if(!Files.isRegularFile(cacheData)) {
+                return false;
+            }
             long manifestLastModified = lastModified(cacheData);
             while (project != null)
             {


### PR DESCRIPTION
This PR should fix [FELIX-6526](https://issues.apache.org/jira/browse/FELIX-6526) and [FELIX-6527](https://issues.apache.org/jira/browse/FELIX-6527).
The case that that the incremental manifest data file does not existing in regular, non-incremental builds was forgotten here and no unit-test for `ManifestPlugin` exists that could have detect that.