### PR TITLE
check if file exist to void NoSuchFileException

### DIFF
--- a/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/ManifestPlugin.java
+++ b/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/ManifestPlugin.java
@@ -426,6 +426,10 @@ public class ManifestPlugin extends BundlePlugin
         try
         { // is pom.xml up-to-date?
             Path cacheData = getIncrementalDataPath(project);
+            if (!Files.exists(cacheData))
+            {
+                return false;
+            }
             long manifestLastModified = lastModified(cacheData);
             while (project != null)
             {


### PR DESCRIPTION
stack trace

Caused by: org.apache.maven.plugin.MojoExecutionException: Error checking manifest uptodate status
    at org.apache.felix.bundleplugin.ManifestPlugin.getManifestUptodateCheckException (ManifestPlugin.java:453)
    at org.apache.felix.bundleplugin.ManifestPlugin.isMetadataUpToDate (ManifestPlugin.java:446)
    at org.apache.felix.bundleplugin.ManifestPlugin.execute (ManifestPlugin.java:108)
    at org.apache.felix.bundleplugin.BundlePlugin.execute (BundlePlugin.java:380)

Signed-off-by: Olivier Lamy <olamy@apache.org>
