### PR TITLE
FELIX-6523 BundlesStartedCheck status is not aligned with other configs in the General HC

### DIFF
--- a/healthcheck/generalchecks/src/main/java/org/apache/felix/hc/generalchecks/BundlesStartedCheck.java
+++ b/healthcheck/generalchecks/src/main/java/org/apache/felix/hc/generalchecks/BundlesStartedCheck.java
@@ -123,7 +123,7 @@ public class BundlesStartedCheck implements HealthCheck {
                     if(useCriticalForInactive) {
                         log.critical(msg, msgObjs);
                     } else {
-                        log.warn(msg, msgObjs);
+                        log.temporarilyUnavailable(msg, msgObjs);
                     }
                     bundleIsLogged = true;
                     inactiveCount++;

--- a/healthcheck/generalchecks/src/test/java/org/apache/felix/hc/generalchecks/BundlesStartedCheckTest.java
+++ b/healthcheck/generalchecks/src/test/java/org/apache/felix/hc/generalchecks/BundlesStartedCheckTest.java
@@ -85,7 +85,7 @@ public class BundlesStartedCheckTest {
         BundlesStartedCheck check = createCheck(emptyMap());
         Bundle bundle = mockBundle("mybundle", Bundle.RESOLVED);
         Result result = executeCheck(check, bundle);
-        assertThat(result.getStatus(), equalTo(Status.WARN));
+        assertThat(result.getStatus(), equalTo(Status.TEMPORARILY_UNAVAILABLE));
     }
     
     @Test
@@ -118,7 +118,7 @@ public class BundlesStartedCheckTest {
         BundlesStartedCheck check = createCheck(emptyMap());
         Bundle bundle = mockBundle("mybundle", Bundle.STARTING);
         Result result = executeCheck(check, bundle);
-        assertThat(result.getStatus(), equalTo(Status.WARN));
+        assertThat(result.getStatus(), equalTo(Status.TEMPORARILY_UNAVAILABLE));
         System.out.println(result);
     }
     
@@ -130,7 +130,7 @@ public class BundlesStartedCheckTest {
         Bundle bundle3 = mockBundle("stoppingbundle", Bundle.STOPPING);
         Bundle bundle4 = mockBundle("startunkownstatebundle", 50);
         Result result = executeCheck(check, bundle, bundle2, bundle3, bundle4);
-        assertThat(result.getStatus(), equalTo(Status.WARN));
+        assertThat(result.getStatus(), equalTo(Status.TEMPORARILY_UNAVAILABLE));
     }
 
     private Hashtable<String, String> withHeader(String key, String value) {


### PR DESCRIPTION
making bundleStartedCheck to return TEMPORARILY_UNAVAILABLE instead of WARN to make it consistent with other health checks