### PR TITLE
FELIX-6542 ScriptedHealthCheck should handle ScriptEngineFactory defined in a fragment bundle

### DIFF
--- a/healthcheck/generalchecks/src/main/java/org/apache/felix/hc/generalchecks/ScriptedHealthCheck.java
+++ b/healthcheck/generalchecks/src/main/java/org/apache/felix/hc/generalchecks/ScriptedHealthCheck.java
@@ -75,7 +75,7 @@ public class ScriptedHealthCheck implements HealthCheck {
         @AttributeDefinition(name = "Tags", description = "List of tags for this health check, used to select subsets of health checks for execution e.g. by a composite health check.")
         String[] hc_tags() default {};
 
-        @AttributeDefinition(name = "Language", description = "The language the script is written in. To use e.g. 'groovy', ensure osgi bundle 'groovy-all' is available.")
+        @AttributeDefinition(name = "Language", description = "The language the script is written in. To use e.g. 'groovy', ensure osgi bundle 'groovy-jsr223' is available.")
         String language() default "groovy";
 
         @AttributeDefinition(name = "Script", description = "The script itself (either use 'script' or 'scriptUrl').")

--- a/healthcheck/generalchecks/src/main/java/org/apache/felix/hc/generalchecks/ScriptedHealthCheck.java
+++ b/healthcheck/generalchecks/src/main/java/org/apache/felix/hc/generalchecks/ScriptedHealthCheck.java
@@ -57,7 +57,7 @@ public class ScriptedHealthCheck implements HealthCheck {
     public static final String HC_LABEL = "Health Check: Script";
     public static final String JCR_FILE_URL_PREFIX = "jcr:";
 
-    @ObjectClassDefinition(name = HC_LABEL, description = "Runs an arbitrary script in given scriping language (via javax.script). "
+    @ObjectClassDefinition(name = HC_LABEL, description = "Runs an arbitrary script in given scripting language (via javax.script). "
             + "The script has the following default bindings available: 'log', 'scriptHelper' and 'bundleContext'. "
             + "'log' is an instance of org.apache.felix.hc.api.FormattingResultLog and is used to define the result of the HC. "
             + "'scriptHelper.getService(classObj)' can be used as shortcut to retrieve a service."

--- a/healthcheck/generalchecks/src/test/java/org/apache/felix/hc/generalchecks/util/DummyScriptEngineFactory.java
+++ b/healthcheck/generalchecks/src/test/java/org/apache/felix/hc/generalchecks/util/DummyScriptEngineFactory.java
@@ -1,0 +1,147 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.felix.hc.generalchecks.util;
+
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
+
+/**
+ * A dummy script engine factory.
+ *
+ */
+public class DummyScriptEngineFactory implements ScriptEngineFactory {
+
+    class DummyScriptEngine implements ScriptEngine {
+
+        public Bindings createBindings() {
+            return new SimpleBindings();
+        }
+
+        public Object eval(String arg0) throws ScriptException {
+            throw new UnsupportedOperationException();
+        }
+
+        public Object eval(Reader arg0) throws ScriptException {
+            throw new UnsupportedOperationException();
+        }
+
+        public Object eval(String arg0, ScriptContext arg1) throws ScriptException {
+            throw new UnsupportedOperationException();
+        }
+
+        public Object eval(Reader arg0, ScriptContext arg1) throws ScriptException {
+            throw new UnsupportedOperationException();
+        }
+
+        public Object eval(String arg0, Bindings arg1) throws ScriptException {
+            throw new UnsupportedOperationException();
+        }
+
+        public Object eval(Reader arg0, Bindings arg1) throws ScriptException {
+            throw new UnsupportedOperationException();
+        }
+
+        public Object get(String arg0) {
+            throw new UnsupportedOperationException();
+        }
+
+        public Bindings getBindings(int arg0) {
+            throw new UnsupportedOperationException();
+        }
+
+        public ScriptContext getContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        public ScriptEngineFactory getFactory() {
+            return DummyScriptEngineFactory.this;
+        }
+
+        public void put(String arg0, Object arg1) {
+            // NO-OP
+        }
+
+        public void setBindings(Bindings arg0, int arg1) {
+            // NO-OP
+        }
+
+        public void setContext(ScriptContext arg0) {
+            // NO-OP
+        }
+
+    }
+
+    public String getEngineName() {
+        return "Dummy Scripting Engine";
+    }
+
+    public String getEngineVersion() {
+        return "1.0";
+    }
+
+    public List<String> getExtensions() {
+        return Arrays.asList("dum", "dummy");
+    }
+
+    public String getLanguageName() {
+        return "dummy";
+    }
+
+    public String getLanguageVersion() {
+        return "2.0";
+    }
+
+    public String getMethodCallSyntax(String arg0, String arg1, String... arg2) {
+        throw new UnsupportedOperationException();
+    }
+
+    public List<String> getMimeTypes() {
+        return Collections.singletonList("application/x-dummy");
+    }
+
+    public List<String> getNames() {
+        return Arrays.asList("Dummy", "dummy");
+    }
+
+    public String getOutputStatement(String arg0) {
+        throw new UnsupportedOperationException();
+    }
+
+    public Object getParameter(String arg0) {
+        throw new UnsupportedOperationException();
+    }
+
+    public String getProgram(String... arg0) {
+        throw new UnsupportedOperationException();
+    }
+
+    public ScriptEngine getScriptEngine() {
+        return new DummyScriptEngine();
+    }
+
+}

--- a/healthcheck/generalchecks/src/test/java/org/apache/felix/hc/generalchecks/util/ScriptEnginesTrackerTest.java
+++ b/healthcheck/generalchecks/src/test/java/org/apache/felix/hc/generalchecks/util/ScriptEnginesTrackerTest.java
@@ -1,0 +1,96 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.felix.hc.generalchecks.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+
+public class ScriptEnginesTrackerTest {
+
+    private static Class<?> SCRIPT_ENGINE_FACTORY = DummyScriptEngineFactory.class;
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBundledScriptEngineFactory() throws Exception {
+        final URL url = createFactoryFile().toURI().toURL();
+        Bundle bundle = mock(Bundle.class);
+        when(bundle.getBundleId()).thenReturn(1L);
+        when(bundle.loadClass(SCRIPT_ENGINE_FACTORY.getName())).thenReturn((Class)SCRIPT_ENGINE_FACTORY);
+        when(bundle.findEntries(ScriptEnginesTracker.META_INF_SERVICES, ScriptEnginesTracker.FACTORY_NAME, false)).thenReturn(Collections.enumeration(Collections.singleton(url)));
+
+        // simulate a bundle starting that declares a new ScriptEngineFactory
+        BundleEvent bundleEvent = new BundleEvent(BundleEvent.STARTED, bundle);
+        ScriptEnginesTracker scriptEngineTracker = new ScriptEnginesTracker(); // context.getService(ScriptEnginesTracker.class);
+        assertNotNull("Expected that the ScriptEnginesTracker would already be registered.", scriptEngineTracker);
+        scriptEngineTracker.bundleChanged(bundleEvent);
+        Map<Bundle, List<String>> languagesByBundle = scriptEngineTracker.getLanguagesByBundle();
+        AtomicInteger factoriesSize = new AtomicInteger(0);
+        languagesByBundle.values().stream()
+            .forEach(l -> factoriesSize.addAndGet(l.size()));
+        int expectedScriptEngineFactories = 1;
+        assertEquals("Expected " + expectedScriptEngineFactories + " ScriptEngineFactories.", expectedScriptEngineFactories, factoriesSize.intValue());
+        List<String> factoriesForBundle = languagesByBundle.get(bundle);
+        assertEquals(1, factoriesForBundle.size());
+        assertEquals("dummy", factoriesForBundle.get(0));
+        assertEquals("Dummy Scripting Engine", scriptEngineTracker.getEngineByLanguage("dummy").getFactory().getEngineName());
+
+        // simulate a bundle stopping that previously declared a new ScriptEngineFactory
+        bundleEvent = new BundleEvent(BundleEvent.STOPPED, bundle);
+        scriptEngineTracker.bundleChanged(bundleEvent);
+        expectedScriptEngineFactories--;
+
+        factoriesSize.set(0);
+        languagesByBundle = scriptEngineTracker.getLanguagesByBundle();
+        assertNotNull(languagesByBundle);
+        languagesByBundle.values().stream()
+            .forEach(l -> factoriesSize.addAndGet(l.size()));
+        assertFalse(languagesByBundle.containsKey(bundle));
+        assertEquals("Expected " + expectedScriptEngineFactories + " ScriptEngineFactory.", expectedScriptEngineFactories, factoriesSize.intValue());
+        assertNull("Did not expect references to the already unregistered DummyScriptEngineFactory", 
+                scriptEngineTracker.getEngineByLanguage("dummy"));
+    }
+
+    private File createFactoryFile() throws IOException {
+        File tempFile = File.createTempFile("scriptEngine", "tmp");
+        tempFile.deleteOnExit();
+        try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+            fos.write("#I'm a test-comment\n".getBytes());
+            fos.write(SCRIPT_ENGINE_FACTORY.getName().getBytes());
+        }
+        return tempFile;
+    }
+
+}


### PR DESCRIPTION
The ScriptEnginesTracker in the Felix Health Check General Checks should handle loading of ScriptEngineFactory serviceloader (/META-INF/services/javax.script.ScriptEngineFactory) files that exist in a fragment.

For example, consider the groovy ScriptEngine that has these:
    Host Bundle - org.codehaus.groovy:groovy:3.0.9
    Fragment - org.codehaus.groovy:groovy-jsr223:3.0.9

Expected:
The groovy ScriptEngineFactory declared in the groovy-jsr223 fragment should be discovered and made available.
