### PR TITLE
[FELIX-6545] HttpRequestsCheck add support for http response code constraint checks

### DIFF
--- a/healthcheck/generalchecks/src/test/java/org/apache/felix/hc/generalchecks/HttpRequestsCheckTest.java
+++ b/healthcheck/generalchecks/src/test/java/org/apache/felix/hc/generalchecks/HttpRequestsCheckTest.java
@@ -151,6 +151,21 @@ public class HttpRequestsCheckTest {
         ResponseCheckResult checkResult = responseTimeCheck.checkResponse(response, log);
         assertEquals("Expected "+expectedTrueOrFalse + " for expression ["+constraint+"] against json: "+time+"ms", expectedTrueOrFalse, !checkResult.contraintFailed);
     }
+
+    @Test
+    public void testCodeConstraint() {
+        assertCodeConstraint(200, "< 500", true);
+        assertCodeConstraint(403, "between 200 and 500", true);
+        assertCodeConstraint(503, "< 500", false);
+        assertCodeConstraint(201, "= 201", true);
+    }
+
+    private void assertCodeConstraint(int code, String constraint, boolean expectedTrueOrFalse) {
+        HttpRequestsCheck.ResponseCodeConstraintCheck responseTimeCheck = new HttpRequestsCheck.ResponseCodeConstraintCheck(constraint);
+        HttpRequestsCheck.Response response = new HttpRequestsCheck.Response(code, "OK", null, "", 1000);
+        ResponseCheckResult checkResult = responseTimeCheck.checkResponse(response, log);
+        assertEquals("Expected "+expectedTrueOrFalse + " for expression ["+constraint+"] against json: "+code, expectedTrueOrFalse, !checkResult.contraintFailed);
+    }
     
     @Test
     public void testSplitArgsRespectingQuotes() throws Exception {


### PR DESCRIPTION
Enhance HttpRequestsCheck to handle http response code constraint checks. Currently only equality checks are supported for http response code checks, this PR introduces support for simple constraint checks for response code.

For example:
- /path/example.html => CODE < 500
- /path/example.html => CODE = 200

