### PR TITLE
FELIX-6547 bump bndlib to 6.3.1. This fixes invalid osgi.ee Require-Capability generation

### DIFF
--- a/tools/maven-bundle-plugin/pom.xml
+++ b/tools/maven-bundle-plugin/pom.xml
@@ -172,7 +172,7 @@
   <dependency>
     <groupId>biz.aQute.bnd</groupId>
     <artifactId>biz.aQute.bndlib</artifactId>
-    <version>6.2.0</version>
+    <version>6.3.1</version>
   </dependency>
   <dependency>
     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
FELIX-6547 bump bndlib to 6.3.1. This fixes invalid osgi.ee Require-Capability generation