### PR TITLE
Fix for FELIX-6563: [Regression] Webconsole REST API doesn't return C…

### DIFF
--- a/webconsole/src/main/java/org/apache/felix/webconsole/internal/configuration/ConfigAdminSupport.java
+++ b/webconsole/src/main/java/org/apache/felix/webconsole/internal/configuration/ConfigAdminSupport.java
@@ -115,7 +115,7 @@ class ConfigAdminSupport {
      * @throws IOException If a problem occurs
      * @throws ValidationException If the configuration is not valid
      */
-    void applyConfiguration( final HttpServletRequest request, final String pid, final String[] propertyList, final boolean isUpdate )
+    String applyConfiguration( final HttpServletRequest request, final String pid, final String[] propertyList, final boolean isUpdate )
             throws ValidationException, IOException
     {
         final String factoryPid = request.getParameter( ConfigManager.FACTORY_PID );
@@ -303,6 +303,7 @@ class ConfigAdminSupport {
             }
         }
         config.update( props );
+        return config.getPid();
     }
 
     public void deleteConfiguration(final String pid) throws ValidationException, IOException {

--- a/webconsole/src/main/java/org/apache/felix/webconsole/internal/configuration/ConfigManager.java
+++ b/webconsole/src/main/java/org/apache/felix/webconsole/internal/configuration/ConfigManager.java
@@ -156,8 +156,7 @@ public class ConfigManager extends SimpleWebConsolePlugin implements OsgiManager
                 }
 
                 try {
-                    cas.applyConfiguration( request, pid, propertyList.split(","), ACTION_UPDATE.equals(request.getParameter(ACTION_APPLY)));
-                    String redirect = pid;
+                    String redirect = cas.applyConfiguration( request, pid, propertyList.split(","), ACTION_UPDATE.equals(request.getParameter(ACTION_APPLY)));
                     if (pidFilter != null) {
                         redirect = redirect.concat("?").concat(PID_FILTER).concat("=").concat(pidFilter);
                     }


### PR DESCRIPTION
Fix for [FELIX-6563]: (https://issues.apache.org/jira/browse/FELIX-6563) 
[Regression] Webconsole REST API doesn't return Confguration PID when creating a new configuration.

The function applyConfiguration generate the pid and should return it so that it can be sent in the redirect location.