### PR TITLE
FELIX-6602 sort resources and exported packages

### DIFF
--- a/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
+++ b/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
@@ -1938,6 +1938,7 @@ public class BundlePlugin extends AbstractMojo
             scanner.scan();
 
             String[] paths = scanner.getIncludedFiles();
+            Arrays.sort( paths );
             for ( int i = 0; i < paths.length; i++ )
             {
                 packages.put( analyzer.getPackageRef( getPackageName( paths[i] ) ) );
@@ -2076,7 +2077,9 @@ public class BundlePlugin extends AbstractMojo
                 scanner.addDefaultExcludes();
                 scanner.scan();
 
-                List<String> includedFiles = Arrays.asList( scanner.getIncludedFiles() );
+                String[] f = scanner.getIncludedFiles();
+                Arrays.sort( f );
+                List<String> includedFiles = Arrays.asList( f );
 
                 for ( Iterator<String> j = includedFiles.iterator(); j.hasNext(); )
                 {


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/FELIX-6602

tested on a few projects (mybatis-3, activemq-artemis), using disorderfs to make sure that these 2 changes fix last remaining issues