### PR TITLE
[Health Check] SFL4j 2.x compatibility

### DIFF
--- a/healthcheck/api/bnd.bnd
+++ b/healthcheck/api/bnd.bnd
@@ -8,5 +8,6 @@ Bundle-License: Apache License, Version 2.0
 
 Bundle-Vendor: The Apache Software Foundation
 
-Export-Package: org.apache.felix.hc.api.*
+Export-Package: !org.apache.felix.hc.api.util,\
+    org.apache.felix.hc.api.*
 

--- a/healthcheck/api/src/main/java/org/apache/felix/hc/api/FormattingResultLog.java
+++ b/healthcheck/api/src/main/java/org/apache/felix/hc/api/FormattingResultLog.java
@@ -20,8 +20,8 @@ package org.apache.felix.hc.api;
 import java.text.NumberFormat;
 import java.util.Locale;
 
+import org.apache.felix.hc.api.util.FormatUtil;
 import org.osgi.annotation.versioning.ProviderType;
-import org.slf4j.helpers.MessageFormatter;
 
 /** Utility that provides a logging-like facade on a ResultLog. */
 @ProviderType
@@ -131,10 +131,10 @@ public class FormattingResultLog extends ResultLog {
         
 
     private ResultLog.Entry createEntry(Result.Status status, String message, Object... args) {
-        return new ResultLog.Entry(status, MessageFormatter.arrayFormat(message, args).getMessage());
+        return new ResultLog.Entry(status, FormatUtil.format(message, args));
     }
     
     private ResultLog.Entry createEntry(boolean isDebug, String message, Object... args) {
-        return new ResultLog.Entry(MessageFormatter.arrayFormat(message, args).getMessage(), isDebug);
+        return new ResultLog.Entry(FormatUtil.format(message, args), isDebug);
     }
 }

--- a/healthcheck/api/src/main/java/org/apache/felix/hc/api/util/FormatUtil.java
+++ b/healthcheck/api/src/main/java/org/apache/felix/hc/api/util/FormatUtil.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The SF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.felix.hc.api.util;
+
+public class FormatUtil {
+
+    private static final String PLACEHOLDER = "{}";
+
+    private FormatUtil() {
+
+    }
+
+    public static String format(String message, Object ... arguments) {
+        if (message == null) {
+            return null;
+        }
+        if (arguments == null || arguments.length == 0) {
+            return message;
+        }
+
+        final StringBuilder builder = new StringBuilder();
+
+        int argumentIndex = 0;
+        int from = 0;
+        int index;
+        while (true) {
+            index = message.indexOf(PLACEHOLDER, from);
+
+            if (index == -1) {
+                // No remaining placeholder found, breaking while loop
+                break;
+            }
+
+            // Append all text up to the placeholder
+            builder.append(message, from, index);
+
+            if (argumentIndex < arguments.length) {
+                // Append the argument from the array whom's index corresponds with the occurrence of the placeholder
+                builder.append(arguments[argumentIndex]);
+                argumentIndex++;
+            } else {
+                // If there are no arguments left, append the placeholder to the output
+                builder.append(PLACEHOLDER);
+            }
+
+            // Update the 'from' to search for the next placeholder
+            from = index + PLACEHOLDER.length();
+        }
+
+        if (from < message.length()) {
+            // Append the remainder of the input string to complete the output
+            builder.append(message.substring(from));
+        }
+
+        return builder.toString();
+    }
+}

--- a/healthcheck/api/src/test/java/org/apache/felix/hc/api/util/FormatUtilTest.java
+++ b/healthcheck/api/src/test/java/org/apache/felix/hc/api/util/FormatUtilTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The SF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.felix.hc.api.util;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class FormatUtilTest {
+    @Test
+    public void formatTest() {
+        assertEquals("one two three", FormatUtil.format("one {} three", "two"));
+        assertEquals("5 ", FormatUtil.format("{} ", 5));
+        assertEquals("true [one, two]", FormatUtil.format("{} {}", true, Arrays.asList("one", "two")));
+    }
+
+    @Test
+    public void noArguments() {
+        assertNull(FormatUtil.format(null));
+        assertEquals("test", FormatUtil.format("test"));
+        assertEquals("test", FormatUtil.format("test", (Object[]) null));
+    }
+
+    @Test
+    public void tooFewArguments() {
+        assertEquals("one two {}", FormatUtil.format("one {} {}", "two"));
+    }
+
+    @Test
+    public void tooManyArguments() {
+        assertEquals("one two three", FormatUtil.format("one {} three", "two", "four"));
+    }
+}


### PR DESCRIPTION
Currently Felix Health Check cannot be used in a runtime where SLF4j 2.x is deployed. I traced this to Health Check's API dependency on the `org.slf4j.helpers.MessageFormatter`. This PR replaces this dependency with a custom format implementation that should be equivalent to what was used from SLF4j API.

Some background: HC API currently builds against SLF4j 1.7.x, and uses both the api package itself and the MessageFormatter from the `org.slf4j.helpers` package. Within SLF4j 2.x, the main API package is exported in both 1.7.36 and 2.x, allowing this bundle to serve both SLF4j 1.7.x users and 2.x users. This "double version export" is not done for the helpers package, and thus the current HC API bundle cannot resolve when SLF4j 2.x is deployed.