### PR TITLE
FELIX-6633 : Dynamic references may miss events while causing deactivation

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/manager/DependencyManager.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/manager/DependencyManager.java
@@ -412,6 +412,11 @@ public class DependencyManager<S, T> implements ReferenceManager<S, T>
                 m_componentManager.getLogger().log(Level.DEBUG,
                     "dm {0} tracking {1} MultipleDynamic removed (deactivate) {2}",
                     null, getName(), trackingCount, serviceReference );
+                if (event != null) {
+                    // After event has been processed make sure to check if we missed anything
+                    // while deactivating; this will possibly reactivate
+                    event.addComponentManager(m_componentManager);
+                }
             }
             ungetService(refPair);
         }
@@ -1136,6 +1141,11 @@ public class DependencyManager<S, T> implements ReferenceManager<S, T>
                 tracked(trackingCount);
                 untracked = false;
                 deactivateComponentManager();
+                if (event != null) {
+                    // After event has been processed make sure to check if we missed anything
+                    // while deactivating; this will possibly reactivate
+                    event.addComponentManager(m_componentManager);
+                }
             }
 
             if (untracked) // not ours

--- a/scr/src/test/resources/integration_test_simple_components_configuration_change.xml
+++ b/scr/src/test/resources/integration_test_simple_components_configuration_change.xml
@@ -150,8 +150,12 @@
     <scr:component name="test_optional_multiple_dynamic"
         enabled="false"
         configuration-policy="require"
-        modified="modified">
+        modified="modified"
+        immediate="true">
         <implementation class="org.apache.felix.scr.integration.components.SimpleComponent" />
+        <service>
+            <provide interface='org.apache.felix.scr.integration.components.SimpleComponent' />
+        </service>
         <reference
             name="ref"
             interface="org.apache.felix.scr.integration.components.SimpleService"


### PR DESCRIPTION
Ensure no new add events got missed when deactivating on removed service

This change follows the same pattern as other reference types but also does it for dynamic references when they become unsatisfied.

The fix is to simply cause the dependency manager to be checked again after the removed event gets processed to ensure the dependency is not now satisfied.