### PR TITLE
Adds Requirement for Configuration Admin

### DIFF
--- a/configurator/pom.xml
+++ b/configurator/pom.xml
@@ -74,6 +74,9 @@
                         <Provide-Capability>
                             osgi.extender;osgi.extender="osgi.configurator";version:Version="1.0"
                         </Provide-Capability>
+                        <Require-Capability>
+                            osgi.implementation;filter:='(&(osgi.implementation=osgi.cm)(version>=1.6.0)(!(version>=2.0.0)))'
+                        </Require-Capability>    
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The Configurator has no requirement for the Configuration Admin, because without it it, the bundle is useless.