### PR TITLE
Add jetty websocket support to Jetty12 

### DIFF
--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <felix.java.version>17</felix.java.version>
-        <jetty.version>12.0.6</jetty.version>
+        <jetty.version>12.0.7</jetty.version>
         <baseline.skip>true</baseline.skip>
     </properties>
 

--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -433,11 +433,6 @@
            <version>${jetty.version}</version>
         </dependency>
         <dependency>
-          <groupId>org.eclipse.jetty.websocket</groupId>
-          <artifactId>jetty-websocket-jetty-client</artifactId>
-          <version>${jetty.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.servlet</artifactId>
             <version>2.0.0</version>

--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -37,7 +37,6 @@
         <connection>scm:git:https://github.com/apache/felix-dev.git</connection>
         <developerConnection>scm:git:https://github.com/apache/felix-dev.git</developerConnection>
         <url>https://gitbox.apache.org/repos/asf?p=felix-dev.git</url>
-        <tag>org.apache.felix.http.jetty12-1.0.3</tag>
     </scm>
 
     <properties>

--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <felix.java.version>17</felix.java.version>
-        <jetty.version>12.0.7</jetty.version>
+        <jetty.version>12.0.8</jetty.version>
         <baseline.skip>true</baseline.skip>
     </properties>
 

--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -30,7 +30,7 @@
     <description>This is an implementation of the R8.1 OSGi Servlet Service, the R7 OSGi Http Service and the R7 OSGi Http Whiteboard Specification</description>
 
     <artifactId>org.apache.felix.http.jetty12</artifactId>
-    <version>1.0.3_BC</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <scm>

--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -30,19 +30,19 @@
     <description>This is an implementation of the R8.1 OSGi Servlet Service, the R7 OSGi Http Service and the R7 OSGi Http Whiteboard Specification</description>
 
     <artifactId>org.apache.felix.http.jetty12</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.3_BC</version>
     <packaging>bundle</packaging>
 
     <scm>
         <connection>scm:git:https://github.com/apache/felix-dev.git</connection>
         <developerConnection>scm:git:https://github.com/apache/felix-dev.git</developerConnection>
         <url>https://gitbox.apache.org/repos/asf?p=felix-dev.git</url>
-        <tag>org.apache.felix.http.jetty12-1.0.2</tag>
+        <tag>org.apache.felix.http.jetty12-1.0.3</tag>
     </scm>
 
     <properties>
         <felix.java.version>17</felix.java.version>
-        <jetty.version>12.0.5</jetty.version>
+        <jetty.version>12.0.6</jetty.version>
         <baseline.skip>true</baseline.skip>
     </properties>
 
@@ -181,6 +181,9 @@
                             org.apache.commons.*
                         </Conditional-Package>
                         <Import-Package>
+                            jakarta.annotation.*;resolution:=optional,
+                            jakarta.transaction.*;resolution:=optional,
+                            org.objectweb.asm.*;resolution:=optional,
                             sun.misc;resolution:=optional,
                             sun.nio.ch;resolution:=optional,
                             javax.imageio;resolution:=optional,
@@ -365,6 +368,11 @@
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+            <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <version>${jetty.version}</version>
@@ -413,6 +421,21 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-session</artifactId>
             <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+           <groupId>org.eclipse.jetty.websocket</groupId>
+           <artifactId>jetty-websocket-jetty-api</artifactId>
+           <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+           <groupId>org.eclipse.jetty.websocket</groupId>
+           <artifactId>jetty-websocket-jetty-server</artifactId>
+           <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty.websocket</groupId>
+          <artifactId>jetty-websocket-jetty-client</artifactId>
+          <version>${jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/http/samples/whiteboard/pom.xml
+++ b/http/samples/whiteboard/pom.xml
@@ -32,6 +32,10 @@
     <version>3.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
+    <properties>
+        <jetty.version>12.0.8</jetty.version>
+    </properties>
+
     <scm>
         <connection>scm:git:https://github.com/apache/felix-dev.git</connection>
         <developerConnection>scm:git:https://github.com/apache/felix-dev.git</developerConnection>
@@ -87,6 +91,36 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.servlet</artifactId>
             <version>2.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.jetty12</artifactId>
+            <version>1.0.3-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.api</artifactId>
+            <version>3.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+            <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
+            <version>${jetty.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>jetty-websocket-jetty-api</artifactId>
+            <version>${jetty.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>jetty-websocket-jetty-server</artifactId>
+            <version>${jetty.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/Activator.java
+++ b/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/Activator.java
@@ -75,6 +75,23 @@ public final class Activator
         filter2Props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT,
                 "(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=filtersample)");
         context.registerService(Filter.class, filter2, filter2Props);
+
+        /**
+         * Register a WebSocket servlet on /filtersample/websocket/*.
+         * In the Chrome Console, this snippet can be used to send a message to the WebSocket:
+         *
+         * const websocket = new WebSocket("ws://localhost:8080/filtersample/websocket/example");
+         * websocket.send("test");
+         *
+         * This will log "test" to the stdout.
+         */
+        final TestWebSocketServlet webSocketServlet = new TestWebSocketServlet("websocketservlet1");
+        final Dictionary<String, Object> webSocketServletProps = new Hashtable<>();
+        webSocketServletProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, "/websocket/*");
+        webSocketServletProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT,
+                "(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=filtersample)");
+        context.registerService(Servlet.class, webSocketServlet, webSocketServletProps);
+
     }
 
     @Override

--- a/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/FelixJettyWebSocketServlet.java
+++ b/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/FelixJettyWebSocketServlet.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.felix.http.samples.whiteboard;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServerContainer;
+import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.ee10.websocket.server.internal.JettyServerFrameHandlerFactory;
+import org.eclipse.jetty.ee10.websocket.servlet.WebSocketUpgradeFilter;
+import org.eclipse.jetty.websocket.core.server.WebSocketMappings;
+import org.eclipse.jetty.websocket.core.server.WebSocketServerComponents;
+
+/**
+ * Abstract class that hides all Jetty Websocket specifics and provides a way for the developer to focus on the actual WebSocket implementation.
+ * @author paulrutters
+ */
+public abstract class FelixJettyWebSocketServlet extends JettyWebSocketServlet {
+
+    private final AtomicBoolean myFirstInitCall = new AtomicBoolean(true);
+    private final CountDownLatch myInitBarrier = new CountDownLatch(1);
+    private ServletContext myProxiedContext;
+    private ServletContextHandler myServletContextHandler;
+
+    @Override
+    public void init() throws ServletException {
+        // Init, delaying init call until service method is called...
+    }
+
+    @Override
+    public void destroy() {
+        // only call destroy when the servlet has been initialized
+        if (!myFirstInitCall.get()) {
+            // This is required because WebSocketServlet needs to have it's destroy() method called as well
+            // Causes NPE otherwise when calling an WS endpoint
+            super.destroy();
+        }
+    }
+
+
+    // This is a workaround required for WebSockets to work in Jetty12, see
+    // https://www.eclipse.org/forums/index.php/t/1110140/
+    @Override
+    public synchronized ServletContext getServletContext() {
+        if (myProxiedContext == null) {
+            myProxiedContext = (ServletContext) Proxy.newProxyInstance(JettyWebSocketServlet.class.getClassLoader(),
+                    new Class[]{ServletContext.class}, (proxy, method, methodArgs) -> {
+                        final ServletContext osgiServletContext = super.getServletContext();
+                        if (!"getAttribute".equals(method.getName())) {
+                            return method.invoke(osgiServletContext, methodArgs);
+                        }
+
+                        final String name = (String) methodArgs[0];
+                        Object value = osgiServletContext.getAttribute(name);
+                        if (value == null && myProxiedContext != null) {
+                            final ServletContext jettyServletContext = myServletContextHandler.getServletContext();
+                            value = jettyServletContext.getAttribute(name);
+                        }
+                        return value;
+                    });
+        }
+
+        return myProxiedContext;
+    }
+
+    @Override
+    protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if (myFirstInitCall.compareAndSet(true, false)) {
+            try {
+                delayedInit();
+            } catch (Exception e) {
+                System.err.println("Error delayed init: " + e.getMessage());
+            } finally {
+                myInitBarrier.countDown();
+            }
+        } else {
+            try {
+                myInitBarrier.await();
+            } catch (final InterruptedException e) {
+                throw new ServletException("Timed out waiting for initialisation", e);
+            }
+        }
+
+        // Call JettyWebSocketServlet service method to handle upgrade requests
+        super.service(req, resp);
+    }
+
+    private void delayedInit() throws ServletException {
+        // Make sure WebSockets are enabled in Jetty12
+        ensureWebSocketsInitialized();
+
+        // Overide the TCCL so that the internal factory can be found
+        // Jetty tries to use ServiceLoader, and their fallback is to
+        // use TCCL, it would be better if we could provide a loader...
+        final Thread currentThread = Thread.currentThread();
+        final ClassLoader tccl = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(JettyWebSocketServlet.class.getClassLoader());
+        try {
+            super.init();
+        } finally {
+            currentThread.setContextClassLoader(tccl);
+        }
+    }
+
+    private void ensureWebSocketsInitialized() {
+        final ServletContext osgiServletContext = getServletContext();
+        myServletContextHandler = ServletContextHandler.getServletContextHandler(osgiServletContext, "WebSockets");
+
+        final JettyWebSocketServerContainer serverContainer = JettyWebSocketServerContainer
+                .getContainer(osgiServletContext);
+        if (serverContainer == null) {
+            // Ensure WebSocket components are initialized in Jetty12
+            final ServletContext jettyServletContext = myServletContextHandler.getServletContext();
+            WebSocketServerComponents.ensureWebSocketComponents(myServletContextHandler.getServer(),
+                    myServletContextHandler);
+            WebSocketUpgradeFilter.ensureFilter(jettyServletContext);
+            WebSocketMappings.ensureMappings(myServletContextHandler);
+            JettyServerFrameHandlerFactory.getFactory(jettyServletContext);
+            JettyWebSocketServerContainer.ensureContainer(jettyServletContext);
+        }
+    }
+}

--- a/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/TestWebSocketServlet.java
+++ b/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/TestWebSocketServlet.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServletFactory;
 import org.eclipse.jetty.ee10.websocket.server.internal.JettyServerFrameHandlerFactory;
 import org.eclipse.jetty.ee10.websocket.servlet.WebSocketUpgradeFilter;
+import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
@@ -193,6 +194,9 @@ public class TestWebSocketServlet extends JettyWebSocketServlet {
         @OnWebSocketOpen
         public void onOpen(final Session session) {
             doLog("Opened session: " + session);
+
+            // send a message to the client
+            session.sendText("Hello from server", Callback.NOOP);
         }
 
         @OnWebSocketError

--- a/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/TestWebSocketServlet.java
+++ b/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/TestWebSocketServlet.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.felix.http.samples.whiteboard;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServerContainer;
+import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServletFactory;
+import org.eclipse.jetty.ee10.websocket.server.internal.JettyServerFrameHandlerFactory;
+import org.eclipse.jetty.ee10.websocket.servlet.WebSocketUpgradeFilter;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketOpen;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.eclipse.jetty.websocket.core.server.WebSocketMappings;
+import org.eclipse.jetty.websocket.core.server.WebSocketServerComponents;
+
+public class TestWebSocketServlet extends JettyWebSocketServlet {
+    private final String name;
+    private final AtomicBoolean myFirstInitCall = new AtomicBoolean(true);
+    private final CountDownLatch myInitBarrier = new CountDownLatch(1);
+    private ServletContext myProxiedContext;
+    private ServletContextHandler myServletContextHandler;
+
+    public TestWebSocketServlet(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void init() throws ServletException {
+        doLog("Init, delaying init call until service method is called...");
+    }
+
+    private void doLog(String message) {
+        System.out.println("## [" + this.name + "] " + message);
+    }
+
+    @Override
+    protected void configure(JettyWebSocketServletFactory jettyWebSocketServletFactory) {
+        doLog("Configuring WebSocket factory");
+        jettyWebSocketServletFactory.register(TestWebSocket.class);
+    }
+
+    @Override
+    public void destroy() {
+        doLog("Destroyed servlet");
+
+        // only call destroy when the servlet has been initialized
+        if (!myFirstInitCall.get()) {
+            // This is required because WebSocketServlet needs to have it's destroy() method called as well
+            // Causes NPE otherwise when calling an WS endpoint
+            super.destroy();
+        }
+    }
+
+    // This is a workaround required for WebSockets to work in Jetty12, see
+    // https://www.eclipse.org/forums/index.php/t/1110140/
+    @Override
+    public synchronized ServletContext getServletContext() {
+        if (myProxiedContext == null) {
+            myProxiedContext = (ServletContext) Proxy.newProxyInstance(JettyWebSocketServlet.class.getClassLoader(),
+                    new Class[]{ServletContext.class}, (proxy, method, methodArgs) -> {
+                        final ServletContext osgiServletContext = super.getServletContext();
+                        if (!"getAttribute".equals(method.getName())) {
+                            return method.invoke(osgiServletContext, methodArgs);
+                        }
+
+                        final String name = (String) methodArgs[0];
+                        Object value = osgiServletContext.getAttribute(name);
+                        if (value == null && myProxiedContext != null) {
+                            final ServletContext jettyServletContext = myServletContextHandler.getServletContext();
+                            value = jettyServletContext.getAttribute(name);
+                        }
+                        return value;
+                    });
+        }
+
+        return myProxiedContext;
+    }
+
+    @Override
+    protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if (myFirstInitCall.compareAndSet(true, false)) {
+            try {
+                delayedInit();
+            } catch (Exception e) {
+                System.err.println("Error delayed init: " + e.getMessage());
+            } finally {
+                myInitBarrier.countDown();
+            }
+        } else {
+            try {
+                myInitBarrier.await();
+            } catch (final InterruptedException e) {
+                throw new ServletException("Timed out waiting for initialisation", e);
+            }
+        }
+
+        if (isWebsocketUpgradeRequest(req)) {
+            try {
+                doLog("Upgrading to websocket request...");
+                // Call WebSocketServlet service method first to handle upgrade requests
+                super.service(req, resp);
+            } catch (final Exception e) {
+                System.err.println("Error while upgrading to websocket request: " + e.getMessage());
+            } finally {
+                doLog("Done, upgrading to websocket request.");
+            }
+        }
+    }
+
+    /**
+     * Returns true if the request is an upgrade request for WebSockets.
+     *
+     * @param request
+     * @return
+     */
+    private static boolean isWebsocketUpgradeRequest(final HttpServletRequest request) {
+        return "GET".equals(request.getMethod()) && !request.getHeader("Upgrade").isEmpty();
+    }
+
+    private void delayedInit() throws ServletException {
+        doLog("Delayed init...");
+
+        // Make sure WebSockets are enabled in Jetty12
+        ensureWebSocketsInitialized();
+
+        // Overide the TCCL so that the internal factory can be found
+        // Jetty tries to use ServiceLoader, and their fallback is to
+        // use TCCL, it would be better if we could provide a loader...
+        final Thread currentThread = Thread.currentThread();
+        final ClassLoader tccl = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(JettyWebSocketServlet.class.getClassLoader());
+        try {
+            super.init();
+        } finally {
+            currentThread.setContextClassLoader(tccl);
+        }
+    }
+
+    private void ensureWebSocketsInitialized() {
+        doLog("Ensuring websockets");
+        final ServletContext osgiServletContext = getServletContext();
+        myServletContextHandler = ServletContextHandler.getServletContextHandler(osgiServletContext, "WebSockets");
+
+        final JettyWebSocketServerContainer serverContainer = JettyWebSocketServerContainer
+                .getContainer(osgiServletContext);
+        if (serverContainer == null) {
+            // Ensure WebSocket components are initialized in Jetty12
+            final ServletContext jettyServletContext = myServletContextHandler.getServletContext();
+            WebSocketServerComponents.ensureWebSocketComponents(myServletContextHandler.getServer(),
+                    myServletContextHandler);
+            WebSocketUpgradeFilter.ensureFilter(jettyServletContext);
+            WebSocketMappings.ensureMappings(myServletContextHandler);
+            JettyServerFrameHandlerFactory.getFactory(jettyServletContext);
+            JettyWebSocketServerContainer.ensureContainer(jettyServletContext);
+        }
+    }
+
+    @WebSocket
+    public static class TestWebSocket {
+        @OnWebSocketMessage
+        public void onText(final Session session, final String message) {
+            doLog("Received message: " + message);
+        }
+
+        @OnWebSocketOpen
+        public void onOpen(final Session session) {
+            doLog("Opened session: " + session);
+        }
+
+        @OnWebSocketError
+        public void onError(final Session session, final Throwable error) {
+            doLog("Error on session: " + session + " - " + error);
+        }
+
+        @OnWebSocketClose
+        public void onClose(final Session session, final int statusCode, final String reason) {
+            doLog("Closed session: " + session + " - " + statusCode + " - " + reason);
+        }
+
+        private void doLog(String message) {
+            System.out.println("## [" + this.getClass() + "] " + message);
+        }
+    }
+}

--- a/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/TestWebSocketServlet.java
+++ b/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/TestWebSocketServlet.java
@@ -123,27 +123,10 @@ public class TestWebSocketServlet extends JettyWebSocketServlet {
             }
         }
 
-        if (isWebsocketUpgradeRequest(req)) {
-            try {
-                doLog("Upgrading to websocket request...");
-                // Call WebSocketServlet service method first to handle upgrade requests
-                super.service(req, resp);
-            } catch (final Exception e) {
-                System.err.println("Error while upgrading to websocket request: " + e.getMessage());
-            } finally {
-                doLog("Done, upgrading to websocket request.");
-            }
-        }
-    }
+        doLog("Upgrading to websocket request...");
 
-    /**
-     * Returns true if the request is an upgrade request for WebSockets.
-     *
-     * @param request
-     * @return
-     */
-    private static boolean isWebsocketUpgradeRequest(final HttpServletRequest request) {
-        return "GET".equals(request.getMethod()) && !request.getHeader("Upgrade").isEmpty();
+        // Call JettyWebSocketServlet service method to handle upgrade requests
+        super.service(req, resp);
     }
 
     private void delayedInit() throws ServletException {

--- a/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/TestWebSocketServlet.java
+++ b/http/samples/whiteboard/src/main/java/org/apache/felix/http/samples/whiteboard/TestWebSocketServlet.java
@@ -16,22 +16,10 @@
  */
 package org.apache.felix.http.samples.whiteboard;
 
-import java.io.IOException;
-import java.lang.reflect.Proxy;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServerContainer;
-import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServletFactory;
-import org.eclipse.jetty.ee10.websocket.server.internal.JettyServerFrameHandlerFactory;
-import org.eclipse.jetty.ee10.websocket.servlet.WebSocketUpgradeFilter;
 import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
@@ -39,23 +27,18 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketOpen;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
-import org.eclipse.jetty.websocket.core.server.WebSocketMappings;
-import org.eclipse.jetty.websocket.core.server.WebSocketServerComponents;
 
-public class TestWebSocketServlet extends JettyWebSocketServlet {
+public class TestWebSocketServlet extends FelixJettyWebSocketServlet {
     private final String name;
-    private final AtomicBoolean myFirstInitCall = new AtomicBoolean(true);
-    private final CountDownLatch myInitBarrier = new CountDownLatch(1);
-    private ServletContext myProxiedContext;
-    private ServletContextHandler myServletContextHandler;
 
     public TestWebSocketServlet(String name) {
         this.name = name;
     }
 
     @Override
-    public void init() throws ServletException {
-        doLog("Init, delaying init call until service method is called...");
+    public void init(ServletConfig config) throws ServletException {
+        doLog("Init with config [" + config + "]");
+        super.init(config);
     }
 
     private void doLog(String message) {
@@ -66,105 +49,6 @@ public class TestWebSocketServlet extends JettyWebSocketServlet {
     protected void configure(JettyWebSocketServletFactory jettyWebSocketServletFactory) {
         doLog("Configuring WebSocket factory");
         jettyWebSocketServletFactory.register(TestWebSocket.class);
-    }
-
-    @Override
-    public void destroy() {
-        doLog("Destroyed servlet");
-
-        // only call destroy when the servlet has been initialized
-        if (!myFirstInitCall.get()) {
-            // This is required because WebSocketServlet needs to have it's destroy() method called as well
-            // Causes NPE otherwise when calling an WS endpoint
-            super.destroy();
-        }
-    }
-
-    // This is a workaround required for WebSockets to work in Jetty12, see
-    // https://www.eclipse.org/forums/index.php/t/1110140/
-    @Override
-    public synchronized ServletContext getServletContext() {
-        if (myProxiedContext == null) {
-            myProxiedContext = (ServletContext) Proxy.newProxyInstance(JettyWebSocketServlet.class.getClassLoader(),
-                    new Class[]{ServletContext.class}, (proxy, method, methodArgs) -> {
-                        final ServletContext osgiServletContext = super.getServletContext();
-                        if (!"getAttribute".equals(method.getName())) {
-                            return method.invoke(osgiServletContext, methodArgs);
-                        }
-
-                        final String name = (String) methodArgs[0];
-                        Object value = osgiServletContext.getAttribute(name);
-                        if (value == null && myProxiedContext != null) {
-                            final ServletContext jettyServletContext = myServletContextHandler.getServletContext();
-                            value = jettyServletContext.getAttribute(name);
-                        }
-                        return value;
-                    });
-        }
-
-        return myProxiedContext;
-    }
-
-    @Override
-    protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        if (myFirstInitCall.compareAndSet(true, false)) {
-            try {
-                delayedInit();
-            } catch (Exception e) {
-                System.err.println("Error delayed init: " + e.getMessage());
-            } finally {
-                myInitBarrier.countDown();
-            }
-        } else {
-            try {
-                myInitBarrier.await();
-            } catch (final InterruptedException e) {
-                throw new ServletException("Timed out waiting for initialisation", e);
-            }
-        }
-
-        doLog("Upgrading to websocket request...");
-
-        // Call JettyWebSocketServlet service method to handle upgrade requests
-        super.service(req, resp);
-    }
-
-    private void delayedInit() throws ServletException {
-        doLog("Delayed init...");
-
-        // Make sure WebSockets are enabled in Jetty12
-        ensureWebSocketsInitialized();
-
-        // Overide the TCCL so that the internal factory can be found
-        // Jetty tries to use ServiceLoader, and their fallback is to
-        // use TCCL, it would be better if we could provide a loader...
-        final Thread currentThread = Thread.currentThread();
-        final ClassLoader tccl = currentThread.getContextClassLoader();
-        currentThread.setContextClassLoader(JettyWebSocketServlet.class.getClassLoader());
-        try {
-            super.init();
-        } finally {
-            currentThread.setContextClassLoader(tccl);
-        }
-    }
-
-    private void ensureWebSocketsInitialized() {
-        doLog("Ensuring websockets");
-        final ServletContext osgiServletContext = getServletContext();
-        myServletContextHandler = ServletContextHandler.getServletContextHandler(osgiServletContext, "WebSockets");
-
-        final JettyWebSocketServerContainer serverContainer = JettyWebSocketServerContainer
-                .getContainer(osgiServletContext);
-        if (serverContainer == null) {
-            // Ensure WebSocket components are initialized in Jetty12
-            final ServletContext jettyServletContext = myServletContextHandler.getServletContext();
-            WebSocketServerComponents.ensureWebSocketComponents(myServletContextHandler.getServer(),
-                    myServletContextHandler);
-            WebSocketUpgradeFilter.ensureFilter(jettyServletContext);
-            WebSocketMappings.ensureMappings(myServletContextHandler);
-            JettyServerFrameHandlerFactory.getFactory(jettyServletContext);
-            JettyWebSocketServerContainer.ensureContainer(jettyServletContext);
-        }
     }
 
     @WebSocket


### PR DESCRIPTION
This change makes it possible to use [Jetty WebSocket](https://eclipse.dev/jetty/documentation/jetty-12/programming-guide/index.html#pg-server-websocket-jetty) (not JakartaEE 10) functionality via the Felix HTTP Jetty 12 bundle.

There are still some strange things that need to be done when writing a WebSocket servlet to get it all to work, but that's for a separate change request/bug report. I requested access to the Felix Jira so i can add it to the jira project.

More info about the required changes needed for setting up an actual websocket servlet. I combined the solutions mentioned in the links below (change classloader, delayed init and Jetty container websocket initialization code), otherwise the Websocket servlet fails to be initialized. 
* https://www.eclipse.org/forums/index.php/t/1110140/
* https://issues.apache.org/jira/browse/FELIX-5310

`jetty-websocket-jetty-client` is technically not required, but handy to have available when writing client code (server to server websocket proxy for example). 

@cziegeler for visibility. 