### PR TITLE
Update felix-resolver and add github validation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,23 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Resolver
+      run: mvn -B package --file resolver/pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ dependency-reduced-pom.xml
 /.metadata/
 /workspace/
 .vscode
+bin/
+target_test-classes/

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -29,7 +29,7 @@
   <description>
     Provide OSGi resolver service.
   </description>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <artifactId>org.apache.felix.resolver</artifactId>
   <scm>
      <connection>scm:git:https://github.com/apache/felix-dev.git</connection>
@@ -38,15 +38,17 @@
     <tag>HEAD</tag>
   </scm>
   <dependencies>
-   <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>osgi.annotation</artifactId>
-      <version>6.0.1</version>
+    <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>osgi.annotation</artifactId>
+        <version>8.1.0</version>
+        <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-      <version>5.0.0</version>
+        <groupId>org.osgi</groupId>
+        <artifactId>osgi.core</artifactId>
+        <version>8.0.0</version>
+        <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -68,7 +70,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <felix.java.version>6</felix.java.version>
+    <felix.java.version>8</felix.java.version>
   </properties>
   <build>
     <plugins>
@@ -114,7 +116,7 @@
           <excludes>
             <exclude>src/**/packageinfo</exclude>
             <exclude>src/main/appended-resources/**</exclude>
-			<exclude>src/test/resources/resolution.json</exclude>
+            <exclude>src/test/resources/resolution.json</exclude>
             <exclude>src/test/resources/felix-4914.json</exclude>
           </excludes>
         </configuration>


### PR DESCRIPTION
Currently the felix-resolver project requires to be build on a true java 8 / 6 JDK as there is no release support for java 6, it also uses some older OSGi framework dependencies.

This now does the follwoing:
- increase from Java 1.6 > 1.8
- update to the latest OSGi dependencies
- set the version to 3.0.0-SNAPSHOT to account for upgrade of Java+OSGi
- add a github verification that builds at laest the resolver part.

@tjwatson @stbischof please review