### PR TITLE
FELIX-6699 Skip parsing of repeated Service-Component entries

### DIFF
--- a/scr/changelog.txt
+++ b/scr/changelog.txt
@@ -1,11 +1,17 @@
+Changes in 2.2.12
+-----------------
+** Bug
+    * [FELIX-6699] Skip parsing of repeated Service-Component entries
+
 Changes in 2.2.8
+-----------------
 ** Improvement
     * [FELIX-6463] Changing log levels for DS component getState and registration
 
 ** Bug
     * [FELIX-6616] Dynamic greedy 1..1 references may activate with no reference service bound
     * [FELIX-6633] Dynamic references may miss events while causing deactivation
-    * [FELIX-6682] Felix SCR - 3 TestCases fail in OSGi TCK 
+    * [FELIX-6682] Felix SCR - 3 TestCases fail in OSGi TCK
 
 Changes in 2.2.6
 -----------------
@@ -113,7 +119,7 @@ Changes in 2.1.14
 ** Bug
     * [FELIX-5950] - NPE in MultiplePrototypeRefPair.unsetServiceObject
     * [FELIX-5974] - Prototype scope references are not released on deactivation
-    
+
 Changes in 2.1.12
 -----------------
 ** Bug
@@ -357,7 +363,7 @@ Changes from 1.6.2 to 1.8
     * [FELIX-3915] - [DS] Timing hole between ComponentHolder initial config and registration
     * [FELIX-3952] - [DS] service events can go missing resulting in hang
     * [FELIX-3967] - [DS] NPE in DependencyManager$AbstractCustomizer.isSatisfied
-    * [FELIX-3971] - [DS] SingleDynamicCustomizer doesn't respond correctly to configuration update events. 
+    * [FELIX-3971] - [DS] SingleDynamicCustomizer doesn't respond correctly to configuration update events.
     * [FELIX-3975] - [DS] Give ParseException cause to move out of the stone age
     * [FELIX-3991] - [DS] component deactivation may not complete properly with enough threads
     * [FELIX-4000] - [DS] ConcurrentModificationException in AbstractComponentManager iterating through m_dependencyManagers
@@ -445,7 +451,7 @@ Changes from 1.6.0 to 1.6.2
     * [FELIX-3717] - [DS] unbind method might not have correct parameters
     * [FELIX-3718] - [DS] deactivate might not move component state to unsatisfied
     * [FELIX-3719] - [DS]  disabling a dependency manager should not reset the service count
-    * [FELIX-3723] - ClassCastException on ConfigurationAdmin service creating components 
+    * [FELIX-3723] - ClassCastException on ConfigurationAdmin service creating components
     * [FELIX-3724] - [DS] concurrent getService calls may return null
     * [FELIX-3725] - [DS] hidden dependency on spring junit wrapper from pax exam
     * [FELIX-3726] - Reference target filters defined as component properties are ignored
@@ -647,7 +653,7 @@ Changes from 1.0.0 to 1.0.2
 
 ** Bug
     * [FELIX-490] - Deadlocks may be caused by Declarative Services
-    * [FELIX-539] - Intermittent IllegalArgumentException while using declarative services   
+    * [FELIX-539] - Intermittent IllegalArgumentException while using declarative services
     * [FELIX-550] - SCR registers service component twice after stopping/starting a bundle
     * [FELIX-578] - ComponentFactoryImpl.newInstance() must create the component synchronously
     * [FELIX-579] - NPE in AbstractComponentManager
@@ -680,7 +686,7 @@ Initial Release 1.0.0
     * [FELIX-387] - Fix support for reference service target properties
     * [FELIX-425] - DependencyManager does not correctly handle service counting
     * [FELIX-464] - Cannot retrieve service to be unbound in unbind method taking ServiceReference
-    * [FELIX-489] - Intermittent deadlock while using declarative services in Tuscany   
+    * [FELIX-489] - Intermittent deadlock while using declarative services in Tuscany
 
 ** Improvement
     * [FELIX-128] - Implementing missing ComponentContext methods


### PR DESCRIPTION
When a bundle's Service-Component header contains explicit paths and wildcard paths, it is possible for an explicit descriptor entry to be parsed twice, if it is also matched by a wildcard entry. This results in an ERROR level log similar to that described in [FELIX-2325](https://issues.apache.org/jira/browse/FELIX-2325). The use case which requires this mix of wildcard and non-wildcard entries is probably rare, but such is the situation with https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/3241

In this situation, bnd is used to package the host bundle, and so the descriptors for the DS components contained within it are listed explicitly in the Service-Component header value generated by the bnd tool. 

Additionally, the project packages some optional component descriptors in a sidecar fragment bundle which cannot define its own Service-Component header. 

In order for SCR to load the optional components only when the fragment is attached, they must be listed by the host bundle's Service-Component header, but only implicitly by using a wildcard, so that their absence is not logged when the fragment is not attached.