### PR TITLE
FELIX-6700 Missing o.o.service.servlet.* export-package in felix jetty

### DIFF
--- a/http/jetty/pom.xml
+++ b/http/jetty/pom.xml
@@ -281,7 +281,10 @@
                                     org.osgi.service.http.runtime,
                                     org.osgi.service.http.runtime.dto,
                                     org.osgi.service.http.whiteboard,
-                                    !org.osgi.service.servlet.*,
+                                    org.osgi.service.servlet.context,
+                                    org.osgi.service.servlet.runtime,
+                                    org.osgi.service.servlet.runtime.dto,
+                                    org.osgi.service.servlet.whiteboard,
                                     org.apache.felix.http.jetty,
                                     org.apache.felix.http.javaxwrappers,
                                     org.apache.felix.http.jakartawrappers
@@ -289,7 +292,6 @@
                                 <Private-Package>
                                     org.apache.felix.http.base.*,
                                     org.apache.felix.http.jetty.*,
-                                    org.osgi.service.servlet.*
                                 </Private-Package>
                                 <Import-Package>
                                     org.osgi.service.cm;resolution:=optional;version="[1.3,2)",

--- a/http/jetty/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
+++ b/http/jetty/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
@@ -153,7 +153,7 @@ public abstract class AbstractJettyTestSupport {
      * @param systemProperty the System property which contains the pathname of the test bundle
      * @return the provisioning option
      */
-    public static UrlProvisionOption testBundle(final String systemProperty) {
+    protected UrlProvisionOption testBundle(final String systemProperty) {
         final String pathname = System.getProperty(systemProperty);
         final File file = new File(pathname);
         return bundle(file.toURI().toString());

--- a/http/jetty/src/test/java/org/apache/felix/http/jetty/it/LightClassifierIT.java
+++ b/http/jetty/src/test/java/org/apache/felix/http/jetty/it/LightClassifierIT.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.felix.http.jetty.it;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.bundle;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.UrlProvisionOption;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+
+/**
+ *
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class LightClassifierIT extends AbstractJettyTestSupport {
+
+    @Inject
+    protected BundleContext bundleContext;
+
+    @Override
+    protected Option[] additionalOptions() throws IOException {
+        String jettyVersion = System.getProperty("jetty.version", "11.0.20");
+        return new Option[] {
+                spifly(),
+
+                // Minimum additional jetty dependency bundles
+                mavenBundle().groupId("org.slf4j").artifactId("slf4j-api").version("2.0.13"),
+                mavenBundle().groupId("org.slf4j").artifactId("slf4j-simple").version("2.0.13"),
+                mavenBundle().groupId("commons-io").artifactId("commons-io").version("2.16.1"),
+                mavenBundle().groupId("commons-fileupload").artifactId("commons-fileupload").version("1.5"),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-java-server").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-server").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-http").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty.http2").artifactId("http2-common").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty.http2").artifactId("http2-hpack").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty.http2").artifactId("http2-server").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-io").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-jmx").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-security").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-server").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-servlet").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-util").version(jettyVersion),
+
+                // additional dependencies to verify FELIX-6700
+                mavenBundle().groupId("org.owasp.encoder").artifactId("encoder").version("1.2.3"),
+                mavenBundle().groupId("org.apache.felix").artifactId("org.apache.felix.inventory").version("2.0.0"),
+                mavenBundle().groupId("org.apache.felix").artifactId("org.apache.felix.webconsole").version("5.0.2")
+        };
+    }
+
+    /**
+     * Override to use the "light" classifier variant of the test bundle
+     */
+    @Override
+    protected UrlProvisionOption testBundle(String systemProperty) {
+        String pathname = System.getProperty(systemProperty);
+        pathname = pathname.replace(".jar", "-light.jar");
+        final File file = new File(pathname);
+        return bundle(file.toURI().toString());
+    }
+
+    /**
+     * Verify FELIX-6700 by checking that the webconsole bundle was resolved and active
+     */
+    @Test
+    public void testWebConsoleBundleIsActive() throws Exception {
+        assertNotNull(bundleContext);
+        Optional<Bundle> first = Stream.of(bundleContext.getBundles())
+                .filter(b -> "org.apache.felix.webconsole".equals(b.getSymbolicName()))
+                .findFirst();
+        assertTrue(first.isPresent());
+        assertEquals(Bundle.ACTIVE, first.get().getState());
+    }
+
+}

--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -283,7 +283,10 @@
                                     org.osgi.service.http.runtime,
                                     org.osgi.service.http.runtime.dto,
                                     org.osgi.service.http.whiteboard,
-                                    !org.osgi.service.servlet.*,
+                                    org.osgi.service.servlet.context,
+                                    org.osgi.service.servlet.runtime,
+                                    org.osgi.service.servlet.runtime.dto,
+                                    org.osgi.service.servlet.whiteboard,
                                     org.apache.felix.http.jetty,
                                     org.apache.felix.http.javaxwrappers,
                                     org.apache.felix.http.jakartawrappers
@@ -291,7 +294,6 @@
                                 <Private-Package>
                                     org.apache.felix.http.base.*,
                                     org.apache.felix.http.jetty.*,
-                                    org.osgi.service.servlet.*
                                 </Private-Package>
                                 <Import-Package>
                                     org.osgi.service.cm;resolution:=optional;version="[1.3,2)",

--- a/http/jetty12/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
+++ b/http/jetty12/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
@@ -153,7 +153,7 @@ public abstract class AbstractJettyTestSupport {
      * @param systemProperty the System property which contains the pathname of the test bundle
      * @return the provisioning option
      */
-    public static UrlProvisionOption testBundle(final String systemProperty) {
+    protected UrlProvisionOption testBundle(final String systemProperty) {
         final String pathname = System.getProperty(systemProperty);
         final File file = new File(pathname);
         return bundle(file.toURI().toString());

--- a/http/jetty12/src/test/java/org/apache/felix/http/jetty/it/LightClassifierIT.java
+++ b/http/jetty12/src/test/java/org/apache/felix/http/jetty/it/LightClassifierIT.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.felix.http.jetty.it;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.bundle;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.UrlProvisionOption;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+
+/**
+ *
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class LightClassifierIT extends AbstractJettyTestSupport {
+
+    @Inject
+    protected BundleContext bundleContext;
+
+    @Override
+    protected Option[] additionalOptions() throws IOException {
+        String jettyVersion = System.getProperty("jetty.version", "12.0.8");
+        return new Option[] {
+                spifly(),
+
+                // Minimum additional jetty dependency bundles
+                mavenBundle().groupId("org.slf4j").artifactId("slf4j-api").version("2.0.13"),
+                mavenBundle().groupId("org.slf4j").artifactId("slf4j-simple").version("2.0.13"),
+                mavenBundle().groupId("commons-io").artifactId("commons-io").version("2.16.1"),
+                mavenBundle().groupId("commons-fileupload").artifactId("commons-fileupload").version("1.5"),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-java-server").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-server").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-http").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty.http2").artifactId("jetty-http2-common").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty.http2").artifactId("jetty-http2-hpack").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty.http2").artifactId("jetty-http2-server").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-io").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-jmx").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-security").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-server").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-session").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty.ee10").artifactId("jetty-ee10-servlet").version(jettyVersion),
+                mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-util").version(jettyVersion),
+
+                // additional dependencies to verify FELIX-6700
+                mavenBundle().groupId("org.owasp.encoder").artifactId("encoder").version("1.2.3"),
+                mavenBundle().groupId("org.apache.felix").artifactId("org.apache.felix.inventory").version("2.0.0"),
+                mavenBundle().groupId("org.apache.felix").artifactId("org.apache.felix.webconsole").version("5.0.2")
+        };
+    }
+
+    /**
+     * Override to use the "light" classifier variant of the test bundle
+     */
+    @Override
+    protected UrlProvisionOption testBundle(String systemProperty) {
+        String pathname = System.getProperty(systemProperty);
+        pathname = pathname.replace(".jar", "-light.jar");
+        final File file = new File(pathname);
+        return bundle(file.toURI().toString());
+    }
+
+    /**
+     * Verify FELIX-6700 by checking that the webconsole bundle was resolved and active 
+     */
+    @Test
+    public void testWebConsoleBundleIsActive() throws Exception {
+        assertNotNull(bundleContext);
+        Optional<Bundle> first = Stream.of(bundleContext.getBundles())
+                .filter(b -> "org.apache.felix.webconsole".equals(b.getSymbolicName()))
+                .findFirst();
+        assertTrue(first.isPresent());
+        assertEquals(Bundle.ACTIVE, first.get().getState());
+    }
+
+}


### PR DESCRIPTION
The "light" classifier doesn't export the following packages.  These packages were present in the jar but as a private package.

`org.osgi.service.servlet.context;version="2.0.0";uses:="jakarta.servlet.http,org.osgi.framework"
org.osgi.service.servlet.runtime.dto;version="2.0.0";uses:="org.osgi.dto,org.osgi.framework.dto"
org.osgi.service.servlet.runtime;version="2.0.0";uses:="org.osgi.service.servlet.runtime.dto"
org.osgi.service.servlet.whiteboard;version="2.0.0";uses:="jakarta.servlet"`

This proposal changes those private packages to be exported packages.  Also an integration test is added to verify the functionality.

This ensures that any other bundles that import those packages (i.e. the felix webconsole 5.x) will resolve.

For example, without these changes I get these errors:
```
[ERROR] [bundle-packages] org.apache.felix:org.apache.felix.http.webconsoleplugin:1.1.0: Bundle is importing packages [org.osgi.service.servlet.runtime, org.osgi.service.servlet.runtime.dto] with start order 5 but no bundle is exporting these for that start order.
[ERROR] [bundle-packages] org.apache.felix:org.apache.felix.healthcheck.core:2.2.0: Bundle is importing package org.osgi.service.servlet.context with start order 5 but no bundle is exporting these for that start order.
[ERROR] [bundle-packages] org.apache.felix:org.apache.felix.http.inventoryprinter:1.0.0: Bundle is importing packages [org.osgi.service.servlet.runtime, org.osgi.service.servlet.runtime.dto] with start order 5 but no bundle is exporting these for that start order.
[ERROR] [bundle-packages] org.apache.felix:org.apache.felix.webconsole:5.0.2: Bundle is importing package org.osgi.service.servlet.context with start order 5 but no bundle is exporting these for that start order.
```