### PR TITLE
FELIX-6687 Fix handling of typed properties in felix fileinstall

### DIFF
--- a/fileinstall/pom.xml
+++ b/fileinstall/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.utils</artifactId>
-      <version>1.11.2</version>
+      <version>1.11.8</version>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>


### PR DESCRIPTION
Due to bug in older version of felix-utils fileinstall can't handle all variants of typed properties properly, especially (a, b, c) syntax..