### PR TITLE
FELIX-6725 Update to Jetty 12.0.13 / 11.0.24

### DIFF
--- a/http/jetty/pom.xml
+++ b/http/jetty/pom.xml
@@ -42,7 +42,7 @@
 
     <properties>
         <felix.java.version>11</felix.java.version>
-        <jetty.version>11.0.23</jetty.version>
+        <jetty.version>11.0.24</jetty.version>
         <baseline.skip>true</baseline.skip>
         <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
         <!-- To debug the pax process, override this with -D -->

--- a/http/jetty/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
+++ b/http/jetty/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
@@ -45,7 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class AbstractJettyTestSupport {
-    protected static final String JETTY_VERSION = "11.0.23";
+    protected static final String JETTY_VERSION = "11.0.24";
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -42,7 +42,7 @@
 
     <properties>
         <felix.java.version>17</felix.java.version>
-        <jetty.version>12.0.12</jetty.version>
+        <jetty.version>12.0.13</jetty.version>
         <baseline.skip>true</baseline.skip>
         <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
         <!-- To debug the pax process, override this with -D -->

--- a/http/jetty12/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
+++ b/http/jetty12/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
@@ -45,7 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class AbstractJettyTestSupport {
-    protected static final String JETTY_VERSION = "12.0.12";
+    protected static final String JETTY_VERSION = "12.0.13";
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/http/samples/whiteboard/pom.xml
+++ b/http/samples/whiteboard/pom.xml
@@ -39,7 +39,7 @@
     </scm>
 
     <properties>
-        <jetty.version>12.0.12</jetty.version>
+        <jetty.version>12.0.13</jetty.version>
     </properties>
 
     <build>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/FELIX-6725
- Upgrade Jetty 11 and 12 to latest