### PR TITLE
Use OSGi Annotations to produce felix.log manifest and clean up.

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -8,6 +8,7 @@ on:
       - 'http/**'
       - 'tools/maven-bundle-plugin/**'
       - 'tools/osgicheck-maven-plugin/**'
+      - 'log/**'
       - 'webconsole/**'
   pull_request:
     branches: [ "master" ]
@@ -17,7 +18,8 @@ on:
       - 'tools/maven-bundle-plugin/**'
       - 'tools/osgicheck-maven-plugin/**'
       - 'webconsole/**'
-    
+      - 'log/**'
+
 permissions: {}
 
 jobs:
@@ -50,10 +52,16 @@ jobs:
             - 'tools/osgicheck-maven-plugin/**'
           webconsole:
             - 'webconsole/**'
+          log:
+            - 'log/**'
+
     - name: Felix SCR
       if: steps.changes.outputs.scr == 'true'
       run: mvn -B -V -Dstyle.color=always --file scr/pom.xml clean verify
-    - name: Felix HTTP 
+    - name: Felix Log
+      if: steps.changes.outputs.log == 'true'
+      run: mvn -B -V -Dstyle.color=always --file log/pom.xml clean verify
+    - name: Felix HTTP
       if: steps.changes.outputs.http == 'true'
       run: mvn -B -V -Dstyle.color=always "-Dit.test=!MissingWebsocketDependenciesIT" --file http/pom.xml clean install verify
     - name: Felix Maven bundle plugin 

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
-        maven-version: 3.9.7
+        maven-version: 3.9.9
     - name: Check which subproject changed and build affected ones
       uses: dorny/paths-filter@v3
       id: changes

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.felix</groupId>
     <artifactId>felix-parent</artifactId>
-    <version>6</version>
+    <version>9</version>
     <relativePath>../pom/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -49,11 +49,42 @@
       <groupId>org.osgi</groupId>
       <artifactId>osgi.core</artifactId>
       <version>6.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
+      <version>1.6.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.log</artifactId>
       <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.annotation.bundle</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.annotation.versioning</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.namespace.service</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+      <version>1.5.1</version>
+      <scope>provided</scope>
     </dependency>
    </dependencies>
   <build>
@@ -61,24 +92,16 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>5.1.9</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>
             <Export-Package>org.osgi.service.log,org.osgi.service.log.admin</Export-Package>
-            <Private-Package>org.apache.felix.log</Private-Package>
-            <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
-            <Bundle-Activator>${pom.artifactId}.Activator</Bundle-Activator>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Vendor>The Apache Software Foundation</Bundle-Vendor>
             <Include-Resource>META-INF/LICENSE=LICENSE,META-INF/NOTICE=NOTICE,META-INF/DEPENDENCIES=DEPENDENCIES</Include-Resource>
-            <Require-Capability><![CDATA[
-                osgi.service;filter:="(objectClass=org.osgi.service.cm.ConfigurationAdmin)";effective:=active
-            ]]></Require-Capability>
-            <Provide-Capability><![CDATA[
-                osgi.service;objectClass:List<String>="org.osgi.service.log.LogReaderService";uses:="org.osgi.service.log,org.osgi.service.log.admin",
-                osgi.service;objectClass:List<String>="org.osgi.service.log.LogService,org.osgi.service.log.LoggerFactory";uses:="org.osgi.service.log,org.osgi.service.log.admin",
-                osgi.service;objectClass:List<String>="org.osgi.service.log.admin.LoggerAdmin";uses:="org.osgi.service.log,org.osgi.service.log.admin"
-            ]]></Provide-Capability>
+            <_reproducible>true</_reproducible>
+            <niceManifest>true</niceManifest>
           </instructions>
         </configuration>
       </plugin>

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -92,7 +92,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>5.1.9</version>
+        <version>6.0.0</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/log/src/main/java/org/apache/felix/log/Activator.java
+++ b/log/src/main/java/org/apache/felix/log/Activator.java
@@ -116,7 +116,7 @@ public final class Activator implements BundleActivator
         String storeDebugPropValue = context.getProperty(STORE_DEBUG_PROPERTY);
         if (storeDebugPropValue != null)
         {
-            storeDebug = Boolean.valueOf(storeDebugPropValue).booleanValue();
+            storeDebug = Boolean.parseBoolean(storeDebugPropValue);
         }
 
         return storeDebug;

--- a/log/src/main/java/org/apache/felix/log/Activator.java
+++ b/log/src/main/java/org/apache/felix/log/Activator.java
@@ -21,10 +21,14 @@ package org.apache.felix.log;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
+import org.osgi.annotation.bundle.Header;
+import org.osgi.annotation.bundle.Requirement;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.namespace.service.ServiceNamespace;
+import org.osgi.resource.Namespace;
 import org.osgi.service.log.LogLevel;
 import org.osgi.service.log.LogReaderService;
 import org.osgi.service.log.LogService;
@@ -54,6 +58,10 @@ import org.osgi.service.log.admin.LoggerContext;
  *       the historic log information. The default value is false.</dd>
  * </dl>
  */
+@Header(name = Constants.BUNDLE_ACTIVATOR, value = "${@class}")
+@Requirement(namespace = ServiceNamespace.SERVICE_NAMESPACE,
+             filter = "(objectClass=org.osgi.service.cm.ConfigurationAdmin)",
+             effective = Namespace.EFFECTIVE_ACTIVE)
 public final class Activator implements BundleActivator
 {
     /** The name of the property that defines the maximum size of the log. */

--- a/log/src/main/java/org/apache/felix/log/FormatterLoggerImpl.java
+++ b/log/src/main/java/org/apache/felix/log/FormatterLoggerImpl.java
@@ -32,6 +32,7 @@ public class FormatterLoggerImpl extends LoggerImpl implements FormatterLogger {
         super(name, bundle, log, loggerAdmin);
     }
 
+    @Override
     String format(String format, LogParameters logParameters) {
         StringBuilder sb = new StringBuilder();
 

--- a/log/src/main/java/org/apache/felix/log/Log.java
+++ b/log/src/main/java/org/apache/felix/log/Log.java
@@ -206,7 +206,7 @@ final class Log implements BundleListener, FrameworkListener, ServiceListener
         "FrameworkEvent STARTED",
         "FrameworkEvent ERROR",
         "FrameworkEvent PACKAGES REFRESHED",
-                    "FrameworkEvent STARTLEVEL CHANGED",
+        "FrameworkEvent STARTLEVEL CHANGED",
         "FrameworkEvent WARNING",
         "FrameworkEvent INFO"
     };

--- a/log/src/main/java/org/apache/felix/log/LogEntryImpl.java
+++ b/log/src/main/java/org/apache/felix/log/LogEntryImpl.java
@@ -143,6 +143,7 @@ final class LogEntryImpl implements LogEntry
      * @return the bundle that created this LogEntry object;<code>null</code> if no
      * bundle is associated with this LogEntry object
      */
+    @Override
     public Bundle getBundle()
     {
         return m_bundle;
@@ -155,6 +156,7 @@ final class LogEntryImpl implements LogEntry
      * this LogEntry object; <code>null</code> if no {@link ServiceReference} object
      * was provided
      */
+    @Override
     public ServiceReference<?> getServiceReference()
     {
         return m_serviceReference;
@@ -171,6 +173,7 @@ final class LogEntryImpl implements LogEntry
      * @see org.osgi.service.LogService#LOG_INFO
      * @see org.osgi.service.LogService#LOG_DEBUG
      */
+    @Override
     public int getLevel()
     {
         if (m_legacyLevel != m_level.ordinal()) {
@@ -184,6 +187,7 @@ final class LogEntryImpl implements LogEntry
      * Returns the human readable message associated with this LogEntry object.
      * @return a string containing the message associated with this LogEntry object
      */
+    @Override
     public String getMessage()
     {
         return m_message;
@@ -202,6 +206,7 @@ final class LogEntryImpl implements LogEntry
      * @return throwable object of the exception associated with this LogEntry;
      * <code>null</code> if no exception is associated with this LogEntry object
      */
+    @Override
     public Throwable getException()
     {
         return m_exception;
@@ -213,6 +218,7 @@ final class LogEntryImpl implements LogEntry
      * @return the system time in milliseconds when this LogEntry object was created
      * @see System#currentTimeMillis()
      */
+    @Override
     public long getTime()
     {
         return m_time;

--- a/log/src/main/java/org/apache/felix/log/LogListenerThread.java
+++ b/log/src/main/java/org/apache/felix/log/LogListenerThread.java
@@ -106,6 +106,7 @@ final class LogListenerThread extends Thread
      * The main method of the thread: waits for new messages to be receieved
      * and then delivers them to any registered log listeners.
      */
+    @Override
     public void run()
     {
         while (!isInterrupted())
@@ -138,10 +139,10 @@ final class LogListenerThread extends Thread
             {
                 // Take a snapshot of all current listeners and deliver all
                 // pending messages to them...
-                List<LogListener> listeners = new ArrayList<>();
+                List<LogListener> listeners;
                 synchronized (m_listeners)
                 {
-                    listeners.addAll(m_listeners);
+                    listeners = new ArrayList<>(m_listeners);
                 }
 
                 Iterator<LogEntry> entriesIt = entriesToDeliver.iterator();

--- a/log/src/main/java/org/apache/felix/log/LogNodeEnumeration.java
+++ b/log/src/main/java/org/apache/felix/log/LogNodeEnumeration.java
@@ -48,6 +48,7 @@ final class LogNodeEnumeration implements Enumeration<LogEntry>
      * Determines whether there are any more elements to return.
      * @return <code>true</code> if there are more elements; <code>false</code> otherwise
      */
+    @Override
     public boolean hasMoreElements()
     {
         return m_next != null;
@@ -57,6 +58,7 @@ final class LogNodeEnumeration implements Enumeration<LogEntry>
      * Returns the current element and moves onto the next element.
      * @return the current element
      */
+    @Override
     public LogEntry nextElement()
     {
         LogEntry result = null;

--- a/log/src/main/java/org/apache/felix/log/LogReaderServiceFactory.java
+++ b/log/src/main/java/org/apache/felix/log/LogReaderServiceFactory.java
@@ -47,6 +47,7 @@ final class LogReaderServiceFactory implements ServiceFactory<LogReaderService>
      * @param registration the service registration
      * @return the log reader service implementation for the specified bundle
      */
+    @Override
     public LogReaderService getService(final Bundle bundle,
         final ServiceRegistration<LogReaderService> registration)
     {
@@ -60,6 +61,7 @@ final class LogReaderServiceFactory implements ServiceFactory<LogReaderService>
      * @param registration the service registration
      * @param service the service to release
      */
+    @Override
     public void ungetService(final Bundle bundle,
         final ServiceRegistration<LogReaderService> registration,
         final LogReaderService service)

--- a/log/src/main/java/org/apache/felix/log/LogReaderServiceImpl.java
+++ b/log/src/main/java/org/apache/felix/log/LogReaderServiceImpl.java
@@ -23,6 +23,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
 
+import org.osgi.annotation.bundle.Capability;
+import org.osgi.namespace.service.ServiceNamespace;
 import org.osgi.service.log.LogEntry;
 import org.osgi.service.log.LogListener;
 import org.osgi.service.log.LogReaderService;
@@ -37,6 +39,11 @@ import org.osgi.service.log.LogReaderService;
  * notifications about {@link org.osgi.service.log.LogEntry} objects when they are created
  * through the {@link org.osgi.service.log.LogService}.
  */
+@Capability(
+        namespace = ServiceNamespace.SERVICE_NAMESPACE,
+        attribute = { "objectClass:List<String>=\"org.osgi.service.log.LogReaderService\"" },
+        uses = { LogReaderServiceImpl.class, LogReaderService.class }
+)
 final class LogReaderServiceImpl implements LogReaderService
 {
     /** The log implementation. */

--- a/log/src/main/java/org/apache/felix/log/LogServiceFactory.java
+++ b/log/src/main/java/org/apache/felix/log/LogServiceFactory.java
@@ -34,7 +34,7 @@ final class LogServiceFactory implements ServiceFactory<LogService>
 
     /**
      * Create a new instance.
-     * @param log the log to associate the service implementations with.,
+     * @param loggerAdminImpl
      */
     LogServiceFactory(final LoggerAdminImpl loggerAdminImpl)
     {

--- a/log/src/main/java/org/apache/felix/log/LogServiceImpl.java
+++ b/log/src/main/java/org/apache/felix/log/LogServiceImpl.java
@@ -44,9 +44,8 @@ final class LogServiceImpl implements LogService
 
     /**
      * Create a new instance.
-     * @param log the log implementation
      * @param bundle the bundle associated with this implementation
-     * @param serviceReference
+     * @param loggerAdminImpl
      */
     LogServiceImpl(final Bundle bundle, final LoggerAdminImpl loggerAdminImpl)
     {

--- a/log/src/main/java/org/apache/felix/log/LogServiceImpl.java
+++ b/log/src/main/java/org/apache/felix/log/LogServiceImpl.java
@@ -18,14 +18,23 @@
  */
 package org.apache.felix.log;
 
+import org.osgi.annotation.bundle.Capability;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.ServiceReference;
+import org.osgi.namespace.service.ServiceNamespace;
 import org.osgi.service.log.LogService;
 import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+import org.osgi.service.log.admin.LoggerAdmin;
 
 /**
  * Implementation of the OSGi {@link LogService}.
  */
+@Capability(
+        namespace = ServiceNamespace.SERVICE_NAMESPACE,
+        attribute = { "objectClass:List<String>=\"org.osgi.service.log.LogService,org.osgi.service.log.LoggerFactory\"" },
+        uses = { LogServiceImpl.class, LogService.class, LoggerFactory.class, LoggerAdmin.class }
+)
 final class LogServiceImpl implements LogService
 {
     /** The bundle associated with this implementation. */

--- a/log/src/main/java/org/apache/felix/log/LoggerAdminImpl.java
+++ b/log/src/main/java/org/apache/felix/log/LoggerAdminImpl.java
@@ -24,12 +24,19 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.osgi.annotation.bundle.Capability;
 import org.osgi.framework.Bundle;
+import org.osgi.namespace.service.ServiceNamespace;
 import org.osgi.service.log.FormatterLogger;
 import org.osgi.service.log.Logger;
 import org.osgi.service.log.admin.LoggerAdmin;
 import org.osgi.service.log.admin.LoggerContext;
 
+@Capability(
+        namespace = ServiceNamespace.SERVICE_NAMESPACE,
+        attribute = { "objectClass:List<String>=\"org.osgi.service.log.admin.LoggerAdmin\"" },
+        uses = { LoggerAdminImpl.class, LoggerAdmin.class }
+)
 public class LoggerAdminImpl implements LoggerAdmin {
 
     private final Log m_log;

--- a/log/src/main/java/org/apache/felix/log/LoggerContextImpl.java
+++ b/log/src/main/java/org/apache/felix/log/LoggerContextImpl.java
@@ -47,17 +47,19 @@ public class LoggerContextImpl implements LoggerContext {
         _rootContext = rootLoggerContext;
     }
 
+    @Override
     public String getName() {
         return _name;
     }
 
+    @Override
     public LogLevel getEffectiveLogLevel(String name) {
         _lock.lock();
         try {
             if (_levels != null && !_levels.isEmpty()) {
                 String copy = name;
                 LogLevel level;
-                while (copy.length() > 0) {
+                while (!copy.isEmpty()) {
                     level = _levels.get(copy);
                     if (level != null) {
                         return level;
@@ -74,6 +76,7 @@ public class LoggerContextImpl implements LoggerContext {
         }
     }
 
+    @Override
     public Map<String, LogLevel> getLogLevels() {
         _lock.lock();
         try {
@@ -87,6 +90,7 @@ public class LoggerContextImpl implements LoggerContext {
         }
     }
 
+    @Override
     public void setLogLevels(Map<String, LogLevel> logLevels) {
         _lock.lock();
         try {
@@ -98,6 +102,7 @@ public class LoggerContextImpl implements LoggerContext {
         }
     }
 
+    @Override
     public void clear() {
         _lock.lock();
         try {
@@ -108,6 +113,7 @@ public class LoggerContextImpl implements LoggerContext {
         }
     }
 
+    @Override
     public boolean isEmpty() {
         _lock.lock();
         try {

--- a/log/src/main/java/org/apache/felix/log/RootLoggerContextImpl.java
+++ b/log/src/main/java/org/apache/felix/log/RootLoggerContextImpl.java
@@ -19,9 +19,6 @@
 
 package org.apache.felix.log;
 
-import java.util.Dictionary;
-import java.util.Map;
-
 import org.osgi.service.log.LogLevel;
 import org.osgi.service.log.Logger;
 
@@ -45,12 +42,13 @@ public class RootLoggerContextImpl extends LoggerContextImpl {
         _defaultLevel = defaultLogLevel;
     }
 
+    @Override
     public LogLevel getEffectiveLogLevel(String name) {
         _lock.lock();
         try {
             if (_levels != null && !_levels.isEmpty()) {
                 LogLevel level;
-                while (name.length() > 0) {
+                while (!name.isEmpty()) {
                     level = _levels.get(name);
                     if (level != null) {
                         return level;
@@ -65,16 +63,6 @@ public class RootLoggerContextImpl extends LoggerContextImpl {
         finally {
             _lock.unlock();
         }
-    }
-
-    @Override
-    public void setLogLevels(Map<String, LogLevel> logLevels) {
-        super.setLogLevels(logLevels);
-    }
-
-    @Override
-    void updateLoggerContext(Dictionary<String, Object> properties) {
-        super.updateLoggerContext(properties);
     }
 
     private LogLevel getEffectiveRootLogLevel() {

--- a/pom/pom.xml
+++ b/pom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>31</version>
+        <version>33</version>
         <relativePath />
     </parent>
 

--- a/scr/src/main/java/org/apache/felix/scr/impl/ComponentCommands.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/ComponentCommands.java
@@ -462,16 +462,14 @@ public class ComponentCommands implements ServiceTrackerCustomizer<Object, Servi
                         valueStr = Arrays.toString((byte[]) value);
                     else if (value instanceof short[])
                         valueStr = Arrays.toString((short[]) value);
-                    else if (value instanceof byte[])
-                        valueStr = Arrays.toString((byte[]) value);
                     else if (value instanceof char[])
                         valueStr = Arrays.toString((char[]) value);
                     else if (value instanceof boolean[])
                         valueStr = Arrays.toString((boolean[]) value);
                     else if (value instanceof float[])
-                        valueStr = Arrays.toString((boolean[]) value);
+                        valueStr = Arrays.toString((float[]) value);
                     else if (value instanceof double[])
-                        valueStr = Arrays.toString((boolean[]) value);
+                        valueStr = Arrays.toString((double[]) value);
                     else if (value instanceof Object[])
                         valueStr = Arrays.deepToString((Object[]) value);
                     else


### PR DESCRIPTION
While I was working on reviving felix.logback I was going through the code and I wondered if it could be modernized a little bit. This is the result. I am not sure if it is useful for the project as I have no idea what minimum platform and JVM version it targets.