### PR TITLE
FELIX-6744 Configure policy for maven release plugin

### DIFF
--- a/pom/pom.xml
+++ b/pom/pom.xml
@@ -175,6 +175,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <projectVersionPolicyId>OddEvenVersionPolicy</projectVersionPolicyId>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.geronimo.genesis.plugins</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FELIX-6744

- Configure OddEvenVersionPolicy based on the undocumented rule of having even version number for releases, and odd versions for development