### PR TITLE
Remove Maven `optional` from Jetty bundle for `commons-io`

### DIFF
--- a/http/jetty/pom.xml
+++ b/http/jetty/pom.xml
@@ -465,11 +465,13 @@
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jakarta-server</artifactId>
             <version>${jetty.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jetty-server</artifactId>
             <version>${jetty.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/http/jetty/pom.xml
+++ b/http/jetty/pom.xml
@@ -465,13 +465,11 @@
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jakarta-server</artifactId>
             <version>${jetty.version}</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jetty-server</artifactId>
             <version>${jetty.version}</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -684,19 +684,16 @@
             <groupId>org.eclipse.jetty.ee10.websocket</groupId>
             <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
             <version>${jetty.version}</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.ee10.websocket</groupId>
             <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
             <version>${jetty.version}</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>jetty-websocket-jetty-server</artifactId>
             <version>${jetty.version}</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -735,7 +732,6 @@
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
             <version>1.5</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -684,16 +684,19 @@
             <groupId>org.eclipse.jetty.ee10.websocket</groupId>
             <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
             <version>${jetty.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.ee10.websocket</groupId>
             <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
             <version>${jetty.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>jetty-websocket-jetty-server</artifactId>
             <version>${jetty.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Remove `optional` for `commons-io`, as the Jetty bundle is typically never used as maven dependency.
Optional means something different in maven than to OSGi. The optional OSGi instructions are left intact.

See discussion in https://github.com/apache/felix-dev/pull/367#issuecomment-2587205869