### PR TITLE
Upgrade Http Bridge Dependencies

### DIFF
--- a/http/bridge/pom.xml
+++ b/http/bridge/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>5.0.0</version>
+            <version>6.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -162,13 +162,13 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.http</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.http.whiteboard</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -179,17 +179,17 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.15.0</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.http.base</artifactId>
-            <version>5.1.8</version>
+            <version>5.1.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.http.wrappers</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.6</version>
 	    </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The bridge imports on jakarta.servlet.descriptor avoids to deploy the bridge on Tomcat 11 correctly because Tomcat 11 provides v6.1. All other jakarta dependencies are open to exlude v7, see:
`
Import-Package: jakarta.servlet;version="[5.0,7)",jakarta.servlet.http
 ;version="[5.0,7)",org.osgi.service.useradmin;resolution:=optional;ve
 rsion="[1.1,2)",sun.misc;resolution:=optional,sun.nio.ch;resolution:=
 optional,jakarta.servlet.descriptor;version="[5.0,6)",java.io,java.la
 ng,java.lang.invoke,java.lang.ref,java.lang.reflect,java.math,java.ne
 t,java.nio,java.nio.channels,java.nio.charset,java.nio.file,java.nio.
`
Upgrading the bridge dependencies fixes the problem. Root cause is the reference on the old wrapper version 1.0.2. 