### PR TITLE
Syntax error fix for default filter

### DIFF
--- a/http/proxy/src/main/java/org/apache/felix/http/proxy/impl/DispatcherTracker.java
+++ b/http/proxy/src/main/java/org/apache/felix/http/proxy/impl/DispatcherTracker.java
@@ -28,7 +28,7 @@ import org.osgi.util.tracker.ServiceTracker;
 public final class DispatcherTracker
     extends ServiceTracker<HttpServlet, HttpServlet>
 {
-    final static String DEFAULT_FILTER = "((http.felix.dispatcher=*)(" + Constants.OBJECTCLASS + "=" + HttpServlet.class.getName() + "))";
+    final static String DEFAULT_FILTER = "(&(http.felix.dispatcher=*)(" + Constants.OBJECTCLASS + "=" + HttpServlet.class.getName() + "))";
 
     private final ServletConfig config;
     private HttpServlet dispatcher;


### PR DESCRIPTION
When using the default filter I get the following Exception:
`jakarta.servlet.ServletException: org.osgi.framework.InvalidSyntaxException: Only one top-level operation allowed: (&(objectClass=jakarta.servlet.http.HttpServlet)((http.felix.dispatcher=*)(objectClass=jakarta.servlet.http.HttpServlet)))
	org.apache.felix.http.proxy.AbstractProxyServlet.service(AbstractProxyServlet.java:113)
	jakarta.servlet.http.HttpServlet.service(HttpServlet.java:716)
	org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
	org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:483)
	org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
	org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:663)
	org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
	org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:395)
	org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
	org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:905)
	org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1746)
	org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
	org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1148)
	org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
	org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
	java.base/java.lang.Thread.run(Thread.java:1583)`
The LDAP syntax is not correct here.

By the way, I'm a bit surprised about the query why querying for the objectClass is done twice:
`(&(objectClass=jakarta.servlet.http.HttpServlet)((http.felix.dispatcher=*)(objectClass=jakarta.servlet.http.HttpServlet)))`

Shouldn't be
`(&(http.felix.dispatcher=*)(objectClass=jakarta.servlet.http.HttpServlet))`
enough if no filter is available?