### PR TITLE
Do not print an error when a wildcard is used in component header

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/BundleComponentActivator.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/BundleComponentActivator.java
@@ -270,11 +270,29 @@ public class BundleComponentActivator implements ComponentActivator
                 URL[] descriptorURLs = findDescriptors(m_bundle, descriptorLocation);
                 if (descriptorURLs.length == 0)
                 {
-                    // 112.4.1 If an XML document specified by the header cannot be located in the bundle and its attached
-                    // fragments, SCR must log an error message with the Log Service, if present, and continue.
-                    logger.log(Level.ERROR,
-                        "Component descriptor entry ''{0}'' not found", null,
-                        descriptorLocation);
+                    if (descriptorLocation.contains("*")) {
+                        // 112.4.1 The last component of each path in the Service-Component header may
+                        // use wildcards so that Bundle.findEntries can be used to locate the XML
+                        // document within the bundle and its fragments. For example:
+                        //
+                        // Service-Component: OSGI-INF/*.xml
+                        //
+                        // A Service-Component manifest header specified in a fragment is ignored by
+                        // SCR. However, XML documents referenced by a bundle's Service-Component
+                        // manifest header may be contained in attached fragments.
+
+                        // in case of such wildcard, finding nothing does not mean an error (because it
+                        // *might* be found in a fragment that is attached later.
+                        logger.log(Level.TRACE,
+                                "Component descriptor entry ''{0}'' with wildcard has no matches", null,
+                                descriptorLocation);
+                    } else {
+                        // 112.4.1 If an XML document specified by the header cannot be located in the bundle and its attached
+                        // fragments, SCR must log an error message with the Log Service, if present, and continue.
+                        logger.log(Level.ERROR,
+                            "Component descriptor entry ''{0}'' not found", null,
+                            descriptorLocation);
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
Currently SCR prints an error if one uses a wildcard in the header but nothing matches. But because fragemnts are not allowed to provide an own header, only the host can enable this.

So this now adds an additional check before logging an error that prevents an error from being printed if a wildcard is provided.

See

- https://github.com/osgi/osgi/issues/789
- https://github.com/eclipse-platform/.github/issues/241
- https://github.com/eclipse-lemminx/lemminx/pull/1732
