### PR TITLE
Upgrade to latest jline release and enable the gogo-build

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - 'scr/**'
       - 'http/**'
+      - 'gogo/**'
       - 'tools/maven-bundle-plugin/**'
       - 'tools/osgicheck-maven-plugin/**'
       - 'webconsole/**'
@@ -44,6 +45,8 @@ jobs:
             - 'scr/**'
           http:
             - 'http/**'
+          gogo:
+            - 'gogo/**'
           maven-bundle-plugin:
             - 'tools/maven-bundle-plugin/**'
           maven-osgicheck-plugin:
@@ -65,6 +68,9 @@ jobs:
     - name: Felix Webconsole
       if: steps.changes.outputs.webconsole == 'true'
       run: mvn -B -V -Dstyle.color=always --file webconsole/pom.xml clean install verify
+    - name: Felix Gogo Shell
+      if: steps.changes.outputs.gogo == 'true'
+      run: mvn -B -V -Dstyle.color=always --file gogo/pom.xml clean install verify
     - name: Upload Test Results
       if: always()
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/gogo/jline/pom.xml
+++ b/gogo/jline/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
-            <version>3.13.2</version>
+            <version>3.29.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sshd</groupId>
@@ -94,7 +94,7 @@
                         </Export-Package>
                         <Import-Package>
                             !org.apache.felix.gogo.runtime.threadio,
-                            org.jline*;version="[3.13,4)",
+                            org.jline*;version="[3.29,4)",
                             *
                         </Import-Package>
                     </instructions>

--- a/gogo/jline/src/main/java/org/apache/felix/gogo/jline/Builtin.java
+++ b/gogo/jline/src/main/java/org/apache/felix/gogo/jline/Builtin.java
@@ -18,6 +18,8 @@
  */
 package org.apache.felix.gogo.jline;
 
+import static org.apache.felix.gogo.jline.Shell.getCommands;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
@@ -49,12 +51,12 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.felix.service.command.Job;
-import org.apache.felix.service.command.Process;
 import org.apache.felix.gogo.runtime.CommandSessionImpl;
 import org.apache.felix.service.command.CommandSession;
 import org.apache.felix.service.command.Converter;
 import org.apache.felix.service.command.Function;
+import org.apache.felix.service.command.Job;
+import org.apache.felix.service.command.Process;
 import org.jline.builtins.Commands;
 import org.jline.builtins.Completers.DirectoriesCompleter;
 import org.jline.builtins.Completers.FilesCompleter;
@@ -64,8 +66,7 @@ import org.jline.reader.LineReader;
 import org.jline.reader.ParsedLine;
 import org.jline.reader.Widget;
 import org.jline.terminal.Terminal;
-
-import static org.apache.felix.gogo.jline.Shell.getCommands;
+import org.jline.utils.StyleResolver;
 
 /**
  * gosh built-in commands.
@@ -683,7 +684,7 @@ public class Builtin {
         List<Candidate> candidates = new ArrayList<>();
         new FilesCompleter(session.currentDir()) {
             @Override
-            protected String getDisplay(Terminal terminal, Path p) {
+            protected String getDisplay(Terminal terminal, Path p, StyleResolver resolver, String separator) {
                 return getFileDisplay(session, p);
             }
         }.complete(reader, line, candidates);
@@ -696,7 +697,7 @@ public class Builtin {
         List<Candidate> candidates = new ArrayList<>();
         new DirectoriesCompleter(session.currentDir()) {
             @Override
-            protected String getDisplay(Terminal terminal, Path p) {
+            protected String getDisplay(Terminal terminal, Path p, StyleResolver resolver, String separator) {
                 return getFileDisplay(session, p);
             }
         }.complete(reader, line, candidates);


### PR DESCRIPTION
Currently gogo-jline uses a rather outdated jline release, this upgrades to the latest release and enables the build.