### PR TITLE
FELIX-6760 - Update to Jetty 9.4.57.v20241219 on http-4.x

### DIFF
--- a/http/jetty/pom.xml
+++ b/http/jetty/pom.xml
@@ -42,7 +42,7 @@
     
     <properties>
         <felix.java.version>8</felix.java.version>
-        <jetty.version>9.4.56.v20240826</jetty.version>
+        <jetty.version>9.4.57.v20241219</jetty.version>
     </properties>
 
     <build>


### PR DESCRIPTION
This PR updates the version of jetty to latest available 9.4.x version.