### PR TITLE
[FELIX-6765] - Add a CI-job for Felix Framework

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -10,6 +10,7 @@ on:
       - 'tools/osgicheck-maven-plugin/**'
       - 'log/**'
       - 'webconsole/**'
+      - 'framework/**'
   pull_request:
     branches: [ "master" ]
     paths:
@@ -19,6 +20,7 @@ on:
       - 'tools/osgicheck-maven-plugin/**'
       - 'webconsole/**'
       - 'log/**'
+      - 'framework/**'
 
 permissions: {}
 
@@ -54,6 +56,8 @@ jobs:
             - 'webconsole/**'
           log:
             - 'log/**'
+          framework:
+            - 'framework/**'
 
     - name: Felix SCR
       if: steps.changes.outputs.scr == 'true'
@@ -73,6 +77,9 @@ jobs:
     - name: Felix Webconsole
       if: steps.changes.outputs.webconsole == 'true'
       run: mvn -B -V -Dstyle.color=always --file webconsole/pom.xml clean install verify
+    - name: Felix Framework
+      if: steps.changes.outputs.framework == 'true'
+      run: mvn -B -V -Dstyle.color=always --file framework/pom.xml clean verify
     - name: Upload Test Results
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/framework/doc/changelog.txt
+++ b/framework/doc/changelog.txt
@@ -1,3 +1,9 @@
+Changes from 7.0.5 to 7.1.0
+---------------------------
+
+** Improvement
+    * [FELIX-6765] - Add a CI-job for Felix Framework
+
 Changes from 7.0.4 to 7.0.5
 ---------------------------
 

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.felix</groupId>
     <artifactId>felix-parent</artifactId>
-    <version>6</version>
+    <version>8</version>
     <relativePath>../pom/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -224,8 +224,8 @@
     </dependency>
     <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>1.10.19</version>
+        <artifactId>mockito-core</artifactId>
+        <version>5.16.1</version>
         <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
- ci job
- update mockito-core to mockito to latest version to run on java 17 and not only 8
- update felix-parent version to avoid build issue with `org.codehaus.mojo:ianal-maven-plugin:1.0-alpha-1`