### PR TITLE
Make Pipe.setCurrentPipe public to fix interruption handling in nested shells

### DIFF
--- a/gogo/runtime/src/main/java/org/apache/felix/gogo/runtime/Pipe.java
+++ b/gogo/runtime/src/main/java/org/apache/felix/gogo/runtime/Pipe.java
@@ -107,7 +107,12 @@ public class Pipe implements Callable<Result>, Process
         return CURRENT.get();
     }
 
-    private static Pipe setCurrentPipe(Pipe pipe) {
+    /**
+     * Set the current pipe for the current thread.
+     * @param pipe the pipe to set as current, or null to clear
+     * @return the previous pipe
+     */
+    public static Pipe setCurrentPipe(Pipe pipe) {
         Pipe previous = CURRENT.get();
         CURRENT.set(pipe);
         return previous;


### PR DESCRIPTION
This PR makes the setCurrentPipe method in the Pipe class public to allow proper handling of interruption signals in nested shells. This is needed to fix an issue in JLine where Ctrl+C doesn't properly interrupt commands running in a nested shell.

The issue occurs when a user starts a shell session, then runs the 'sh' command to create a nested shell, and then runs a command like 'ttop' in that nested shell. When the user presses Ctrl+C to interrupt the 'ttop' command, the interruption signal is caught by the parent shell but not properly propagated to the child shell.

By making setCurrentPipe public, we allow the nested shell to clear the current pipe before creating a child shell and restore it afterward, ensuring that interruption signals are properly propagated.

See: https://github.com/jline/jline3/issues/1143