### PR TITLE
FELIX-6773 Fixing an issue which is causing unnecessary downloads

### DIFF
--- a/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/LazyLocalResourceImpl.java
+++ b/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/LazyLocalResourceImpl.java
@@ -115,4 +115,8 @@ public class LazyLocalResourceImpl implements LocalResource
     public boolean equals(Object o) {
         return getResource().equals(o);
     }
+
+    public int hashCode() {
+        return getResource().hashCode();
+    }
 }

--- a/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/LazyLocalResourceImpl.java
+++ b/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/LazyLocalResourceImpl.java
@@ -111,4 +111,6 @@ public class LazyLocalResourceImpl implements LocalResource
     public Requirement[] getRequirements() {
         return getResource().getRequirements();
     }
+
+    public boolean equals(Object o) { return getResource().equals(o); }
 }

--- a/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/LazyLocalResourceImpl.java
+++ b/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/LazyLocalResourceImpl.java
@@ -112,5 +112,7 @@ public class LazyLocalResourceImpl implements LocalResource
         return getResource().getRequirements();
     }
 
-    public boolean equals(Object o) { return getResource().equals(o); }
+    public boolean equals(Object o) {
+        return getResource().equals(o);
+    }
 }


### PR DESCRIPTION
FELIX-6773 Fixing an issue which is causing unnecessary downloads in ResolverImpl due to resources that are equals being reported as unequal.

https://issues.apache.org/jira/browse/FELIX-6773