### PR TITLE
Replace Pax Logging with Logback in Pax Exam tests

### DIFF
--- a/scr/pom.xml
+++ b/scr/pom.xml
@@ -65,7 +65,6 @@
         <bundle.file.name>
             ${bundle.build.name}/${project.build.finalName}.jar
         </bundle.file.name>
-        <felix.ca.version>1.9.0</felix.ca.version>
 
         <java.version>8</java.version>
         <felix.java.version>${java.version}</felix.java.version>
@@ -121,13 +120,13 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.util.promise</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.util.function</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -251,6 +250,18 @@
             <version>5.0.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.pushstream</artifactId>
+            <version>1.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.configadmin</artifactId>
+            <version>1.9.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <directory>${bundle.build.name}</directory>
@@ -315,6 +326,22 @@
                     <excludePackageNames>org.apache.felix.scr.impl:org.apache.felix.scr.impl.*</excludePackageNames>
                     <source>${java.version}</source>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.servicemix.tooling</groupId>
+                <artifactId>depends-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-depends-file</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <outputFile>${project.build.testOutputDirectory}/META-INF/maven/dependencies.properties</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/scr/pom.xml
+++ b/scr/pom.xml
@@ -197,29 +197,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
-            <artifactId>pax-logging-api</artifactId>
-            <version>1.6.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
-            <artifactId>pax-logging-service</artifactId>
-            <version>1.6.3</version>
-            <scope>test</scope>
-        </dependency>
-    
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.3.15</version>
+            <version>1.2.12</version>
             <scope>test</scope>
         </dependency>
-    
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.12</version>
+            <version>1.2.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
@@ -186,16 +186,20 @@ public abstract class ComponentTestBase
                         CoreOptions.bundle( bundleFile.toURI().toString() ),
                         mavenBundle( "org.ops4j.pax.tinybundles", "tinybundles", "1.0.0" ),
                         mavenBundle( "org.osgi", "org.osgi.service.log", "1.4.0"),
+                        mavenBundle( "org.slf4j", "slf4j-api", "1.7.32" ),
+                        mavenBundle( "ch.qos.logback", "logback-core", "1.2.12" ),
+                        mavenBundle( "ch.qos.logback", "logback-classic", "1.2.12" ),
                         mavenBundle( "org.osgi", "org.osgi.util.pushstream", "1.0.0"),
                         mavenBundle( "org.apache.felix", "org.apache.felix.configadmin", felixCaVersion ) ),
-                        mavenBundle( "org.osgi", "org.osgi.util.promise"),
-                        mavenBundle( "org.osgi", "org.osgi.util.function"),
-                        mavenBundle( "org.osgi", "org.osgi.service.component"),
-                        mavenBundle( "org.ops4j.pax.url", "pax-url-aether"),
+                        mavenBundle( "org.osgi", "org.osgi.util.promise", "1.3.0" ),
+                        mavenBundle( "org.osgi", "org.osgi.util.function", "1.2.0" ),
+                        mavenBundle( "org.osgi", "org.osgi.service.component", "1.5.1" ),
+                        mavenBundle( "org.ops4j.pax.url", "pax-url-aether", "2.6.2"),
                 junitBundles(), frameworkProperty( "org.osgi.framework.bsnversion" ).value( bsnVersionUniqueness ),
                 systemProperty( "ds.factory.enabled" ).value( Boolean.toString( NONSTANDARD_COMPONENT_FACTORY_BEHAVIOR ) ),
                 systemProperty( "ds.loglevel" ).value( DS_LOGLEVEL ),
-                systemProperty( "ds.cache.metadata" ).value( Boolean.toString(CACHE_META_DATA) )
+                systemProperty( "ds.cache.metadata" ).value( Boolean.toString(CACHE_META_DATA) ),
+                systemProperty( "logback.configurationFile" ).value( "src/test/resources/logback-test.xml" )
 
                 );
         final Option vmOption = ( paxRunnerVmOption != null )? CoreOptions.vmOption( paxRunnerVmOption ): null;

--- a/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
@@ -139,8 +139,6 @@ public abstract class ComponentTestBase
     //set to true to only get last 1000 lines of log.
     protected static boolean restrictedLogging;
 
-    protected static String felixCaVersion = System.getProperty( "felix.ca.version" );
-
     protected static final String PROP_NAME_FACTORY = ComponentTestBase.PROP_NAME + ".factory";
 
     static
@@ -185,17 +183,17 @@ public abstract class ComponentTestBase
         final Option[] base = options(
                 provision(
                         CoreOptions.bundle( bundleFile.toURI().toString() ),
-                        mavenBundle( "org.ops4j.pax.tinybundles", "tinybundles", "1.0.0" ),
-                        mavenBundle( "org.osgi", "org.osgi.service.log", "1.4.0"),
-                        mavenBundle( "org.slf4j", "slf4j-api", "1.7.32" ),
-                        mavenBundle( "ch.qos.logback", "logback-core", "1.2.12" ),
-                        mavenBundle( "ch.qos.logback", "logback-classic", "1.2.12" ),
-                        mavenBundle( "org.osgi", "org.osgi.util.pushstream", "1.0.0"),
-                        mavenBundle( "org.apache.felix", "org.apache.felix.configadmin", felixCaVersion ) ),
-                        mavenBundle( "org.osgi", "org.osgi.util.promise", "1.3.0" ),
-                        mavenBundle( "org.osgi", "org.osgi.util.function", "1.2.0" ),
-                        mavenBundle( "org.osgi", "org.osgi.service.component", "1.5.1" ),
-                        mavenBundle( "org.ops4j.pax.url", "pax-url-aether", "2.6.2"),
+                        mavenBundle( "org.ops4j.pax.tinybundles", "tinybundles" ).versionAsInProject(),
+                        mavenBundle( "org.osgi", "org.osgi.service.log" ).versionAsInProject(),
+                        mavenBundle( "org.slf4j", "slf4j-api" ).versionAsInProject(),
+                        mavenBundle( "ch.qos.logback", "logback-core" ).versionAsInProject(),
+                        mavenBundle( "ch.qos.logback", "logback-classic" ).versionAsInProject(),
+                        mavenBundle( "org.osgi", "org.osgi.util.pushstream" ).versionAsInProject(),
+                        mavenBundle( "org.apache.felix", "org.apache.felix.configadmin" ).versionAsInProject() ),
+                        mavenBundle( "org.osgi", "org.osgi.util.promise" ).versionAsInProject(),
+                        mavenBundle( "org.osgi", "org.osgi.util.function" ).versionAsInProject(),
+                        mavenBundle( "org.osgi", "org.osgi.service.component" ).versionAsInProject(),
+                        mavenBundle( "org.ops4j.pax.url", "pax-url-aether" ).versionAsInProject(),
                 junitBundles(), frameworkProperty( "org.osgi.framework.bsnversion" ).value( bsnVersionUniqueness ),
                 systemProperty( "ds.factory.enabled" ).value( Boolean.toString( NONSTANDARD_COMPONENT_FACTORY_BEHAVIOR ) ),
                 systemProperty( "ds.loglevel" ).value( DS_LOGLEVEL ),

--- a/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
@@ -18,6 +18,7 @@
  */
 package org.apache.felix.scr.integration;
 
+import static org.ops4j.pax.exam.Constants.EXAM_FAIL_ON_UNRESOLVED_KEY;
 import static org.ops4j.pax.exam.CoreOptions.frameworkProperty;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -199,7 +200,8 @@ public abstract class ComponentTestBase
                 systemProperty( "ds.factory.enabled" ).value( Boolean.toString( NONSTANDARD_COMPONENT_FACTORY_BEHAVIOR ) ),
                 systemProperty( "ds.loglevel" ).value( DS_LOGLEVEL ),
                 systemProperty( "ds.cache.metadata" ).value( Boolean.toString(CACHE_META_DATA) ),
-                systemProperty( "logback.configurationFile" ).value( "src/test/resources/logback-test.xml" )
+                systemProperty( "logback.configurationFile" ).value( "src/test/resources/logback-test.xml" ),
+                systemProperty( EXAM_FAIL_ON_UNRESOLVED_KEY ).value( "true" )
 
                 );
         final Option vmOption = ( paxRunnerVmOption != null )? CoreOptions.vmOption( paxRunnerVmOption ): null;

--- a/scr/src/test/resources/exam.properties
+++ b/scr/src/test/resources/exam.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Prevent PAX Logging to be activated
+pax.exam.logging=none

--- a/scr/src/test/resources/logback-test.xml
+++ b/scr/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<configuration>
+
+    <!-- defined a console append -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%15.15thread] %-5level %-36.36logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="shaded.org.apache.http" level="WARN" />
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Related to PR #420, on getting control on the logging. This changes disables Pax Exam's preference for Pax Logging, and changes it with Logback (in the latest SLF4j 1.7.x compatible version). With this change, SLF4j and Logback are now available for both the unit tests and the pax exam tests.

Configured explicit versions of all 'mavenBundle's declared in the ComponentTestBase, as otherwise Pax will depend on Maven's LATEST, which is not always compatible. By using fixed versions (compatible with what is in the pom file), I also fixed test Felix6274Test, that I noticed failing (both on master and in #419)