### PR TITLE
FELIX-6784 Reduce number of thread (re)creations of the Configurator Worker Thread

### DIFF
--- a/configurator/src/main/java/org/apache/felix/configurator/impl/Configurator.java
+++ b/configurator/src/main/java/org/apache/felix/configurator/impl/Configurator.java
@@ -105,7 +105,7 @@ public class Configurator {
                 if ( active &&
                     (state == Bundle.ACTIVE || state == Bundle.STARTING) ) {
                     SystemLogger.debug("Adding bundle " + getBundleIdentity(bundle) + " : " + getBundleState(state));
-                    queue.enqueue(new Runnable() {
+                    queue.submit(new Runnable() {
 
                         @Override
                         public void run() {
@@ -128,7 +128,7 @@ public class Configurator {
                 final int state = bundle.getState();
                 if ( active && state == Bundle.UNINSTALLED ) {
                     SystemLogger.debug("Removing bundle " + getBundleIdentity(bundle) + " : " + getBundleState(state));
-                    queue.enqueue(new Runnable() {
+                    queue.submit(new Runnable() {
 
                         @Override
                         public void run() {
@@ -148,7 +148,7 @@ public class Configurator {
     }
 
     public void configAdminAdded() {
-        queue.enqueue(new Runnable() {
+        queue.submit(new Runnable() {
 
             @Override
             public void run() {
@@ -182,7 +182,7 @@ public class Configurator {
      */
     public void shutdown() {
         this.active = false;
-        this.queue.stop();
+        this.queue.shutdownNow();
         this.tracker.close();
     }
 


### PR DESCRIPTION
Changed the WorkerQueue to be based on the Java's standard ScheduledThreadPoolExecutor. This already implements keeping track of tasks, and allows for the configuring a keep alive time.