### PR TITLE
Use globalContext for commands if configured

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/Activator.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/Activator.java
@@ -225,7 +225,7 @@ public class Activator extends AbstractExtender
 
         super.doStart();
 
-        m_componentCommands = new ComponentCommands(m_context, runtime, m_configuration);
+        m_componentCommands = new ComponentCommands(m_context, m_globalContext, runtime, m_configuration);
         m_componentCommands.register();
         m_componentCommands.updateProvideScrInfoService(m_configuration.infoAsService());
         m_configuration.setScrCommand(m_componentCommands);

--- a/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
@@ -777,7 +777,7 @@ public abstract class ComponentTestBase
 
         protected InfoWriter(ServiceComponentRuntime scrService)
         {
-            super( null, scrService, null );
+            super( null, null, scrService, null );
         }
 
     }


### PR DESCRIPTION
When the global context is configured then the SCR commands should use the global context to get SCR component information.