### PR TITLE
FELIX-6812: Fix ConfigInstaller to use listConfigurations instead of getConfiguration

### DIFF
--- a/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/ConfigInstaller.java
+++ b/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/ConfigInstaller.java
@@ -237,9 +237,15 @@ public class ConfigInstaller implements ArtifactInstaller, ConfigurationListener
         {
             try
             {
-                Configuration config = getConfigurationAdmin().getConfiguration(
-                                            configurationEvent.getPid(),
-                                            "?");
+                Configuration[] configurations = getConfigurationAdmin().listConfigurations("(service.pid=" + configurationEvent.getPid() + ")");
+                if (null == configurations) {
+                    return;
+                }
+                if (configurations.length < 1) {
+                    return;
+                }
+                Configuration config = configurations[0];
+
                 Dictionary<?,?> dict = config.getProperties();
                 String fileName = dict != null ? (String) dict.get( DirectoryWatcher.FILENAME ) : null;
                 File file = fileName != null ? fromConfigKey(fileName) : null;

--- a/fileinstall/src/test/java/org/apache/felix/fileinstall/internal/ConfigInstallerTest.java
+++ b/fileinstall/src/test/java/org/apache/felix/fileinstall/internal/ConfigInstallerTest.java
@@ -245,10 +245,10 @@ public class ConfigInstallerTest extends TestCase {
         EasyMock.expect(mockBundleContext.getProperty((String) EasyMock.anyObject()))
                 .andReturn(null)
                 .anyTimes();
-        EasyMock.expect(mockConfigurationAdmin.listConfigurations((String) EasyMock.anyObject()))
+        EasyMock.expect(mockConfigurationAdmin.listConfigurations("(felix.fileinstall.filename=file:" + file + ")"))
                 .andReturn(null);
-        EasyMock.expect(mockConfigurationAdmin.getConfiguration(pid, "?"))
-                .andReturn(mockConfiguration);
+        EasyMock.expect(mockConfigurationAdmin.listConfigurations("(service.pid=" + pid + ")"))
+                .andReturn(new Configuration[] { mockConfiguration });
 
         ServiceReference<ConfigurationAdmin> sr = EasyMock.createMock(ServiceReference.class);
         EasyMock.expect(mockConfiguration.updateIfDifferent(EasyMock.capture(props))).andReturn(true);
@@ -327,8 +327,8 @@ public class ConfigInstallerTest extends TestCase {
         EasyMock.expect(mockBundleContext.getProperty((String) EasyMock.anyObject()))
                 .andReturn(null)
                 .anyTimes();
-        EasyMock.expect(mockConfigurationAdmin.listConfigurations((String) EasyMock.anyObject()))
-                .andReturn(null);
+        EasyMock.expect(mockConfigurationAdmin.listConfigurations("(service.pid=" + pid + ")"))
+                .andReturn(new Configuration[] { mockConfiguration });
         EasyMock.expect(mockConfigurationAdmin.getConfiguration(pid, "?"))
                 .andReturn(mockConfiguration);
         EasyMock.expect(mockConfiguration.getPid())
@@ -386,6 +386,9 @@ public class ConfigInstallerTest extends TestCase {
                 .andReturn(cachingPersistenceConfiguration)
                 .anyTimes();
 
+        EasyMock.expect(mockConfigurationAdmin.listConfigurations("(service.pid=" + pid + ")"))
+                .andReturn(new Configuration[] { cachingPersistenceConfiguration });
+
         EasyMock.expect(mockConfigurationAdmin.getConfiguration(pid, null))
                 .andReturn(cachingPersistenceConfiguration)
                 .anyTimes();
@@ -393,7 +396,7 @@ public class ConfigInstallerTest extends TestCase {
         final Configuration newConfiguration = EasyMock.createMock(Configuration.class);
         EasyMock.expect(newConfiguration.getAttributes()).andReturn(Collections.emptySet()).times(2);
 
-        EasyMock.expect(mockConfigurationAdmin.listConfigurations((String) EasyMock.anyObject()))
+        EasyMock.expect(mockConfigurationAdmin.listConfigurations("(felix.fileinstall.filename=file:" + file + ")"))
                 .andReturn(new Configuration[] { newConfiguration });
 
         EasyMock.expect(newConfiguration.getProperties())


### PR DESCRIPTION
Replace `getConfiguration()` call with `listConfigurations()` in `ConfigInstaller.configurationEvent()` method to avoid unintentionally creating new configurations. The `getConfiguration()` method creates a configuration if it doesn't exist, which is not the desired behavior when simply checking for existing configurations.

Changes:
- Use `listConfigurations("(service.pid=" + pid + ")")` instead of `getConfiguration(pid, "?")`
- Add proper null and length checks for configuration arrays
- Update corresponding test mocks to reflect the corrected API usage

This fixes an issue with felix fileinstall reacting upon the CM_UPDATED events and creating a configuration that was already deleted.