### PR TITLE
chore: Log when service fails to instantiate

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/manager/SingleComponentManager.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/manager/SingleComponentManager.java
@@ -932,6 +932,7 @@ public class SingleComponentManager<S> extends AbstractComponentManager<S> imple
                 getLogger().log(Level.ERROR,
                     "Failed to create service from bundle",
                     error);
+                return null;
             }
             finally
             {

--- a/scr/src/main/java/org/apache/felix/scr/impl/manager/SingleComponentManager.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/manager/SingleComponentManager.java
@@ -928,6 +928,10 @@ public class SingleComponentManager<S> extends AbstractComponentManager<S> imple
                     return null;
                 }
 
+            } catch (Throwable error){
+                getLogger().log(Level.ERROR,
+                    "Failed to create service from bundle",
+                    error);
             }
             finally
             {


### PR DESCRIPTION
## Context

Had the following issue during my switch from Jackson 2 to 3:
- my Felix container was upgraded in version 3
- my bundles were still using version 2
- they instantiated some modules
- which were provided by the container
- these modules did not have any namespace change
- so classes were still existing
- but these classes were not usable by Jackson 2

It was really not straightforward to debug due to the lack of logging on the `org.apache.felix.scr.impl.manager.SingleComponentManager#getService(Bundle, ServiceRegistration<S>)` method, and particularly since it caches the result.

<details>

<summary>View an example stack trace</summary>

```
ERROR : bundle my-plugin:2.1.0 (6)[my.plugin.path.MyPluginService(0)] : Failed to create service from bundle
java.lang.VerifyError: Bad type on operand stack
Exception Details:
  Location:
    my/plugin/path.MyPluginService.<clinit>()V @68: invokevirtual
  Reason:
    Type 'io/vavr/jackson/datatype/VavrModule' (current frame, stack[1]) is not assignable to 'com/fasterxml/jackson/databind/Module'
  Current Frame:
    bci: @68
    flags: { }
    locals: { }
    stack: { 'com/fasterxml/jackson/databind/ObjectMapper', 'io/vavr/jackson/datatype/VavrModule' }
  Bytecode:
    0000000: bb01 c959 b702 a4b2 02aa 04b6 02ae b202
    0000010: b403 b602 b7b2 02ba 03b6 02ae b202 beb6
    0000020: 02c2 b202 c8b6 02cc bb02 ce59 b702 cfb6
    0000030: 02d3 bb00 6959 bb00 6759 b702 d404 b602
    0000040: d8b7 02db b602 d3b3 01b5 b1            

	at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:2985)
	at java.base/java.lang.Class.getConstructors(Class.java:2025)
	at org.apache.felix.scr.impl.inject.internal.ComponentConstructorImpl.<init>(ComponentConstructorImpl.java:98)
	at org.apache.felix.scr.impl.inject.internal.ComponentMethodsImpl.initComponentMethods(ComponentMethodsImpl.java:110)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.initDependencyManagers(AbstractComponentManager.java:1029)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.collectDependencies(AbstractComponentManager.java:1057)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.getServiceInternal(SingleComponentManager.java:955)
```

## Goal

The goal of this PR is simply to add a log to let user know when a failure occurs and why, so that he can be aware something wrong occurred and can know the reason behind the linkage issue.