### PR TITLE
Fix an issue where SecureAction#getCanonicalPath can resolve paths to real paths

### DIFF
--- a/framework/src/main/java/org/apache/felix/framework/util/SecureAction.java
+++ b/framework/src/main/java/org/apache/felix/framework/util/SecureAction.java
@@ -1718,7 +1718,8 @@ public class SecureAction
         }
         else
         {
-            return dataFile.getCanonicalPath();
+			// Sanitize the file path. Use an absolute path to be able to resolve special names (e.g. "..")
+            return dataFile.toPath().toAbsolutePath().normalize().toString();
         }
     }
 

--- a/framework/src/main/java/org/apache/felix/framework/util/SecureAction.java
+++ b/framework/src/main/java/org/apache/felix/framework/util/SecureAction.java
@@ -2092,7 +2092,7 @@ public class SecureAction
                         (org.osgi.framework.hooks.weaving.WovenClass) arg2);
                     return null;
                 case GET_CANONICAL_PATH:
-                    return ((File) arg1).getCanonicalPath();
+                    return ((File) arg1).toPath().toAbsolutePath().normalize().toString();
                 case CREATE_PROXY:
                     return Proxy.newProxyInstance((ClassLoader)arg1, (Class<?>[])arg2,
                             (InvocationHandler) arg3);


### PR DESCRIPTION
On Windows, if Apache Felix is run from a `subst` drive (e.g. "`P:\felix`" where "P:" is a "`subst`" drive to "`C:\tmp`"), some internal resources failed to be properly resolved on startup.

I noticed that, with Java 25, an exception occured in `org.apache.felix.framework.Felix#handleJavaVersionChange()`.

```
ERROR: Bundle org.apache.felix.framework [0] The data file must be inside the data dir. Could not create framework: java.lang.NullPointerException: Cannot invoke "java.io.File.isFile()" because "dataFile" is null java.lang.NullPointerException: Cannot invoke "java.io.File.isFile()" because "dataFile" is null
        at org.apache.felix.framework.Felix.handleJavaVersionChange(Felix.java:1012)
        at org.apache.felix.framework.Felix.init(Felix.java:810)
        at org.apache.felix.framework.Felix.init(Felix.java:648)
        at org.apache.felix.main.Main.main(Main.java:289)
```

After some investigation and step-by-step debugging, it appeared that the issue is located in `BundleCache#getSystemBundleDataFile(String)` because the canonical paths are not resolved similarly. This causes the file to be detected as outside of its directory.

```
String dataFilePath = BundleCache.getSecureAction().getCanonicalPath(dataFile);
String dataDirPath = BundleCache.getSecureAction().getCanonicalPath(sbDir);
if (!dataFilePath.equals(dataDirPath) && !dataFilePath.startsWith(dataDirPath + File.separatorChar))
{
    throw new IllegalArgumentException("The data file must be inside the data dir.");
}
```

To prevent this verification from being too dependent on the underlying file-system and the resolution to real paths, this commit leverages `java.nio.file.Path#normalize` to sanitize the file path.