### PR TITLE
FELIX-6841: Fix ArrayIndexOutOfBoundsException in Pipe.isTty

### DIFF
--- a/gogo/runtime/src/main/java/org/apache/felix/gogo/runtime/Pipe.java
+++ b/gogo/runtime/src/main/java/org/apache/felix/gogo/runtime/Pipe.java
@@ -215,7 +215,7 @@ public class Pipe implements Callable<Result>, Process
 
     public boolean isTty(int fd) {
         // TODO: this assumes that the session is always created with input/output tty streams
-        if (fd < 0 || fd > streams.length) {
+        if (fd < 0 || fd >= streams.length) {
             return false;
         }
         return streams[fd] != null && !toclose[fd];

--- a/gogo/runtime/src/test/java/org/apache/felix/gogo/runtime/TestParser.java
+++ b/gogo/runtime/src/test/java/org/apache/felix/gogo/runtime/TestParser.java
@@ -509,6 +509,14 @@ public class TestParser extends AbstractParserTest
         assertEquals(false, c.execute("$(istty 1)"));
     }
 
+    @Test
+    public void testIsTtyOutOfBounds() throws Exception
+    {
+        Context c = new Context();
+        c.addCommand("istty", this);
+        assertEquals(false, c.execute("istty 10"));
+    }
+
     public boolean istty(CommandSession session, int fd)
     {
         return Process.Utils.current().isTty(fd);


### PR DESCRIPTION

Fixes an `ArrayIndexOutOfBoundsException` in `Pipe.isTty(int fd)` when the file descriptor index `fd` is equal to or greater than the `streams` array length.

The boundary check in `Pipe.isTty` used `fd > streams.length` instead of `fd >= streams.length`. Because Java arrays are 0-indexed, checking `fd` at `streams.length` bypassed the check and threw an `ArrayIndexOutOfBoundsException` when accessing `streams[fd]`.


- Updated the check to `fd >= streams.length` to safely return `false` on out-of-bounds descriptors.
- Added `testIsTtyOutOfBounds` in `TestParser.java` and verified the build passes successfully.
