### PR TITLE
FELIX-6842: gogo-jline: Implement support for -u (UTC) option in date command

### DIFF
--- a/gogo/jline/src/main/java/org/apache/felix/gogo/jline/Posix.java
+++ b/gogo/jline/src/main/java/org/apache/felix/gogo/jline/Posix.java
@@ -249,9 +249,18 @@ public class Posix {
         };
         Date input = new Date();
         String output = null;
+        boolean utc = false;
+        for (int i = 1; i < argv.length; i++) {
+            if ("-u".equals(argv[i])) {
+                utc = true;
+            }
+        }
         for (int i = 1; i < argv.length; i++) {
             if ("-?".equals(argv[i]) || "--help".equals(argv[i])) {
                 throw new HelpException(String.join("\n", usage));
+            }
+            else if ("-u".equals(argv[i])) {
+                // handled in pre-scan
             }
             else if ("-r".equals(argv[i])) {
                 if (i + 1 < argv.length) {
@@ -265,7 +274,11 @@ public class Posix {
                     String fmt = argv[++i];
                     String inp = argv[++i];
                     String jfmt = toJavaDateFormat(fmt);
-                    input = new SimpleDateFormat(jfmt).parse(inp);
+                    SimpleDateFormat sdf = new SimpleDateFormat(jfmt);
+                    if (utc) {
+                        sdf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+                    }
+                    input = sdf.parse(inp);
                 } else {
                     throw new IllegalArgumentException("usage: date [-u] [-r seconds] [-v[+|-]val[mwdHMS] ...] [-f input_fmt new_date] [+output_fmt]");
                 }
@@ -285,7 +298,11 @@ public class Posix {
             output = "%c";
         }
         // Print output
-        process.out().println(new SimpleDateFormat(toJavaDateFormat(output)).format(input));
+        SimpleDateFormat sdf = new SimpleDateFormat(toJavaDateFormat(output));
+        if (utc) {
+            sdf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+        }
+        process.out().println(sdf.format(input));
     }
 
     private String toJavaDateFormat(String format) {

--- a/gogo/jline/src/test/java/org/apache/felix/gogo/jline/PosixTest.java
+++ b/gogo/jline/src/test/java/org/apache/felix/gogo/jline/PosixTest.java
@@ -101,6 +101,16 @@ public class PosixTest extends AbstractParserTest {
         assertEquals("       1       5       5", res);
     }
 
+    @Test
+    public void testDateUtc() throws Exception {
+        Context context = new Context();
+        context.addCommand("date", new Posix(context));
+        context.addCommand("tac", this);
+
+        Object res = context.execute("date -u '+%z' | tac");
+        assertEquals("Z", res.toString().trim());
+    }
+
     public String tac() throws IOException {
         StringWriter sw = new StringWriter();
         Reader rdr = new InputStreamReader(System.in);


### PR DESCRIPTION

This PR fixes handling of the documented `-u` (UTC) timezone option in the JLine shell `date` command.

In `org.apache.felix.gogo.jline.Posix.java`, the `date` command usage documentation includes the `-u` option (use UTC), but the argument parsing logic did not recognize it and instead fell through to the default error path, resulting in an `IllegalArgumentException`.

 Detect the `-u` option during argument processing.
 Treat `-u` as a valid option.
 Apply the UTC timezone when parsing or formatting dates.

Added `testDateUtc` in `PosixTest.java`.
Verified the new test passes successfully.
