### PR TITLE
FELIX-6840: Harden XML parsers against XML External Entity (XXE) injection

### DIFF
--- a/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/StaxParser.java
+++ b/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/StaxParser.java
@@ -49,6 +49,8 @@ public class StaxParser extends RepositoryParser
             setProperty(factory, XMLInputFactory.IS_NAMESPACE_AWARE, false);
             setProperty(factory, XMLInputFactory.IS_VALIDATING, false);
             setProperty(factory, XMLInputFactory.IS_COALESCING, false);
+            setProperty(factory, XMLInputFactory.SUPPORT_DTD, false);
+            setProperty(factory, XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
             StaxParser.factory = factory;
         }
         return factory;

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/StreamMetadataProvider.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/StreamMetadataProvider.java
@@ -72,6 +72,14 @@ public class StreamMetadataProvider implements MetadataProvider {
             XMLMetadataParser handler = new XMLMetadataParser();
 
             XMLReader parser = XMLReaderFactory.createXMLReader();
+            try {
+                parser.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                parser.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            } catch (Exception e) {
+                // Ignore
+            }
             parser.setContentHandler(handler);
             parser.setFeature("http://xml.org/sax/features/validation", true);
             parser.setFeature("http://apache.org/xml/features/validation/schema", true);

--- a/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/module/DefaultBindingModule.java
+++ b/ipojo/manipulator/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/module/DefaultBindingModule.java
@@ -273,6 +273,12 @@ public class DefaultBindingModule extends AbsBindingModule {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
             try {
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                factory.setXIncludeAware(false);
                 m_builder = factory.newDocumentBuilder();
             } catch (ParserConfigurationException e) {
                 // TODO GSA is this acceptable to throw a RuntimeException here ?

--- a/ipojo/manipulator/manipulator/src/test/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/HandlerDeclarationVisitorTestCase.java
+++ b/ipojo/manipulator/manipulator/src/test/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/HandlerDeclarationVisitorTestCase.java
@@ -98,6 +98,16 @@ public class HandlerDeclarationVisitorTestCase extends TestCase {
     private DocumentBuilder builder() throws ParserConfigurationException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
+        try {
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setXIncludeAware(false);
+        } catch (Exception e) {
+            // Ignore
+        }
         return factory.newDocumentBuilder();
     }
 }

--- a/scr/src/main/java/org/apache/felix/scr/impl/BundleComponentActivator.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/BundleComponentActivator.java
@@ -427,6 +427,18 @@ public class BundleComponentActivator implements ComponentActivator
                 getConfiguration().keepInstances(), m_trueCondition);
             final SAXParserFactory factory = SAXParserFactory.newInstance();
             factory.setNamespaceAware(true);
+            try
+            {
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setXIncludeAware(false);
+            }
+            catch (Exception e)
+            {
+                logger.log(Level.WARN, "Failed to configure SAXParserFactory to prevent XXE", e);
+            }
             final SAXParser parser = factory.newSAXParser();
 
             parser.parse( stream, handler );

--- a/scr/src/test/java/org/apache/felix/scr/impl/metadata/ComponentBase.java
+++ b/scr/src/test/java/org/apache/felix/scr/impl/metadata/ComponentBase.java
@@ -52,6 +52,18 @@ public class ComponentBase extends TestCase
     {
         final SAXParserFactory factory = SAXParserFactory.newInstance();
         factory.setNamespaceAware(true);
+        try
+        {
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setXIncludeAware(false);
+        }
+        catch (Exception e)
+        {
+            // Ignore
+        }
         final SAXParser parser = factory.newSAXParser();
 
         XmlHandler handler = new XmlHandler(new MockBundle(), logger, false, false, null);

--- a/scr/src/test/java/org/apache/felix/scr/impl/xml/XmlHandlerTest.java
+++ b/scr/src/test/java/org/apache/felix/scr/impl/xml/XmlHandlerTest.java
@@ -111,6 +111,38 @@ public class XmlHandlerTest {
             trueDependency.getTarget());
     }
 
+    @Test(expected = Exception.class)
+    public void testParserRejectsXXE() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<!DOCTYPE scr:component [\n" +
+            "  <!ENTITY xxe SYSTEM \"http://127.0.0.1:9999/test\">\n" +
+            "]>\n" +
+            "<scr:component xmlns:scr=\"http://www.osgi.org/xmlns/scr/v1.0.0\" name=\"test\">\n" +
+            "    <property name=\"val\" value=\"&xxe;\"/>\n" +
+            "    <implementation class=\"test.MyComponent\"/>\n" +
+            "</scr:component>";
+        final Bundle bundle = Mockito.mock(Bundle.class);
+        Mockito.when(bundle.getLocation()).thenReturn("bundle");
+
+        try (java.io.ByteArrayInputStream stream = new java.io.ByteArrayInputStream(xml.getBytes("UTF-8"))) {
+            XmlHandler handler = new XmlHandler(bundle, new MockBundleLogger(), false,
+                false, null);
+            final SAXParserFactory factory = SAXParserFactory.newInstance();
+            factory.setNamespaceAware(true);
+            try {
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setXIncludeAware(false);
+            } catch (Exception e) {
+                // Ignore
+            }
+            final SAXParser parser = factory.newSAXParser();
+            parser.parse(stream, handler);
+        }
+    }
+
     private List<ComponentMetadata> parse(final URL descriptorURL,
         ServiceReference<?> trueCondition) throws Exception
     {
@@ -125,6 +157,15 @@ public class XmlHandlerTest {
                 false, trueCondition);
             final SAXParserFactory factory = SAXParserFactory.newInstance();
             factory.setNamespaceAware(true);
+            try {
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setXIncludeAware(false);
+            } catch (Exception e) {
+                // Ignore
+            }
             final SAXParser parser = factory.newSAXParser();
 
             parser.parse(stream, handler);

--- a/tools/osgicheck-maven-plugin/src/main/java/org/apache/felix/maven/osgicheck/impl/checks/SCRCheck.java
+++ b/tools/osgicheck-maven-plugin/src/main/java/org/apache/felix/maven/osgicheck/impl/checks/SCRCheck.java
@@ -340,6 +340,15 @@ public class SCRCheck implements Check {
         try {
             final SAXParserFactory factory = SAXParserFactory.newInstance();
             factory.setNamespaceAware(true);
+            try {
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setXIncludeAware(false);
+            } catch (final Exception e) {
+                // Ignore or log
+            }
             final SAXParser parser = factory.newSAXParser();
             parser.parse(file, handler);
 

--- a/tools/osgicheck-maven-plugin/src/main/java/org/apache/felix/maven/osgicheck/impl/mddocgen/ServicesMarkdownGeneratorMojo.java
+++ b/tools/osgicheck-maven-plugin/src/main/java/org/apache/felix/maven/osgicheck/impl/mddocgen/ServicesMarkdownGeneratorMojo.java
@@ -147,6 +147,15 @@ public final class ServicesMarkdownGeneratorMojo extends AbstractMarkdownMojo {
             XmlHandler xmlHandler = new XmlHandler(new SyntheticBundle(servicesDirectory, serviceFile), mavenScrLogger, false, true, null);
             final SAXParserFactory factory = SAXParserFactory.newInstance();
             factory.setNamespaceAware(true);
+            try {
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setXIncludeAware(false);
+            } catch (Exception e) {
+                // Ignore or log
+            }
             final SAXParser parser = factory.newSAXParser();
             parser.parse(serviceFile, xmlHandler);
 

--- a/utils/src/main/java/org/apache/felix/utils/repository/StaxParser.java
+++ b/utils/src/main/java/org/apache/felix/utils/repository/StaxParser.java
@@ -436,6 +436,8 @@ public final class StaxParser {
         if (StaxParser.inputFactory == null) {
             XMLInputFactory factory = XMLInputFactory.newInstance();
             factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
+            factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
             StaxParser.inputFactory = factory;
         }
         return StaxParser.inputFactory;


### PR DESCRIPTION
This PR hardens XML parsing across Apache Felix by disabling DTD processing, external entity resolution, and XInclude support in SAX, DOM, StAX, and XMLReader implementations used by core components, libraries, and build tools.

Parser Hardening:Secured XML parser factories in Declarative Services (SCR), iPOJO Manipulator, OSGi Check Maven Plugin, and StAX parsers.
XXE Validation: Added `testParserRejectsXXE` in `XmlHandlerTest` to verify that XML containing external entities or DOCTYPE declarations is safely rejected.
Compatibility: Existing OSGi descriptors do not rely on DTDs or external entities, so the changes are expected to be backward-compatible.