### PR TITLE
FELIX-6839: Resolve lifecycle race condition in EventDispatcher start/stop sequence

### DIFF
--- a/framework.tck/pom.xml
+++ b/framework.tck/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/framework.tck/tck.bndrun
+++ b/framework.tck/tck.bndrun
@@ -30,7 +30,7 @@
 	junit-platform-engine;version='[1.12.1,1.12.2)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
 	junit-platform-launcher;version='[1.12.1,1.12.2)',\
-	assertj-core;version='[3.27.3,3.27.4)',\
+	assertj-core;version='[3.27.7,3.27.8)',\
 	biz.aQute.junit;version='[6.4.1,6.4.2)',\
 	junit-vintage-engine;version='[5.7.1,5.7.2)',\
-	net.bytebuddy.byte-buddy;version='[1.17.5,1.17.6)'
+	net.bytebuddy.byte-buddy;version='[1.18.0,1.18.1)'

--- a/framework/src/main/java/org/apache/felix/framework/EventDispatcher.java
+++ b/framework/src/main/java/org/apache/felix/framework/EventDispatcher.java
@@ -87,6 +87,20 @@ public class EventDispatcher
     {
         synchronized (m_threadLock)
         {
+            // If the thread is stopping, wait until it is fully stopped.
+            while (m_stopping)
+            {
+                try
+                {
+                    m_threadLock.wait();
+                }
+                catch (InterruptedException ex)
+                {
+                    // Restore interrupted status
+                    Thread.currentThread().interrupt();
+                }
+            }
+
             // Start event dispatching thread if necessary.
             if (m_thread == null || !m_thread.isAlive())
             {


### PR DESCRIPTION

This PR addresses a race condition in `EventDispatcher` that can occur during concurrent framework start/stop operations in the same JVM.

 Updated `startDispatching()` to wait while the dispatcher is being stopped.
 Ensures shutdown completes before a new dispatch thread is created, preventing inconsistent dispatcher lifecycle states.
