### PR TITLE
FELIX-6838: Fix Platform-Dependent URI Mock Failures in fileinstall Tests

### DIFF
--- a/fileinstall/src/test/java/org/apache/felix/fileinstall/internal/ConfigInstallerTest.java
+++ b/fileinstall/src/test/java/org/apache/felix/fileinstall/internal/ConfigInstallerTest.java
@@ -245,7 +245,7 @@ public class ConfigInstallerTest extends TestCase {
         EasyMock.expect(mockBundleContext.getProperty((String) EasyMock.anyObject()))
                 .andReturn(null)
                 .anyTimes();
-        EasyMock.expect(mockConfigurationAdmin.listConfigurations("(felix.fileinstall.filename=file:" + file + ")"))
+        EasyMock.expect(mockConfigurationAdmin.listConfigurations("(felix.fileinstall.filename=" + file.getAbsoluteFile().toURI().toString() + ")"))
                 .andReturn(null);
         EasyMock.expect(mockConfigurationAdmin.listConfigurations("(service.pid=" + pid + ")"))
                 .andReturn(new Configuration[] { mockConfiguration });
@@ -396,7 +396,7 @@ public class ConfigInstallerTest extends TestCase {
         final Configuration newConfiguration = EasyMock.createMock(Configuration.class);
         EasyMock.expect(newConfiguration.getAttributes()).andReturn(Collections.emptySet()).times(2);
 
-        EasyMock.expect(mockConfigurationAdmin.listConfigurations("(felix.fileinstall.filename=file:" + file + ")"))
+        EasyMock.expect(mockConfigurationAdmin.listConfigurations("(felix.fileinstall.filename=" + file.getAbsoluteFile().toURI().toString() + ")"))
                 .andReturn(new Configuration[] { newConfiguration });
 
         EasyMock.expect(newConfiguration.getProperties())

--- a/fileinstall/src/test/java/org/apache/felix/fileinstall/internal/DirectoryWatcherTest.java
+++ b/fileinstall/src/test/java/org/apache/felix/fileinstall/internal/DirectoryWatcherTest.java
@@ -289,7 +289,7 @@ public class DirectoryWatcherTest extends TestCase
 
         final String bundleFileName = "firstjar.jar";
         final File bundleFile = new File(watchedDirectoryPath,bundleFileName);
-        final String bundleLocation = "file:"+watchedDirectoryPath+'/'+bundleFileName;
+        final String bundleLocation = new File(watchedDirectoryFile, bundleFileName).toURI().toString();
 
         // break execution
         final Scanner scanner = new Scanner(watchedDirectoryFile)
@@ -341,7 +341,7 @@ public class DirectoryWatcherTest extends TestCase
 
         final String bundleFileName = "firstjar.jar";
         final File bundleFile = new File(watchedDirectoryPath,bundleFileName);
-        final String bundleLocation = "blueprint:file:"+watchedDirectoryPath+'/'+bundleFileName+"$Bundle-SymbolicName=foo&Bundle-Version=1.0";
+        final String bundleLocation = "blueprint:" + new File(watchedDirectoryFile, bundleFileName).toURI().toString() + "$Bundle-SymbolicName=foo&Bundle-Version=1.0";
 
         // break execution
         Scanner scanner = new Scanner(watchedDirectoryFile)
@@ -390,7 +390,7 @@ public class DirectoryWatcherTest extends TestCase
 
         final String bundleFileName = "firstjar.jar";
         final File bundleFile = new File(watchedDirectoryPath,bundleFileName);
-        final String bundleLocation = "blueprint:file:"+watchedDirectoryPath+'/'+bundleFileName;
+        final String bundleLocation = "blueprint:" + new File(watchedDirectoryFile, bundleFileName).toURI().toString();
 
         final Scanner scanner = new Scanner(watchedDirectoryFile)
         {


### PR DESCRIPTION
Fixes failures in `ConfigInstallerTest` and `DirectoryWatcherTest` caused by platform-dependent URI construction in mock expectations.

The tests previously constructed expected file URIs by manually concatenating strings (for example, prefixing paths with `"file:"`). This approach can produce URI formats that differ across operating systems and may not match the URIs generated by the implementation.

Replace manual URI construction with `File.toURI()` to ensure test expectations use the same platform-independent URI representation as the production code, eliminating OS-specific test failures.

