### PR TITLE
FELIX-6837: Skip Write-Protection Test on Unsupported File Systems

### DIFF
--- a/fileinstall/src/test/java/org/apache/felix/fileinstall/internal/DirectoryWatcherTest.java
+++ b/fileinstall/src/test/java/org/apache/felix/fileinstall/internal/DirectoryWatcherTest.java
@@ -244,6 +244,10 @@ public class DirectoryWatcherTest extends TestCase
             File parent = new File("target/tmp");
             parent.mkdirs();
             parent.setWritable(false, false);
+            if (parent.canWrite())
+            {
+                return;
+            }
             File tmp = new File(parent, "tmp");
             System.setProperty("java.io.tmpdir", tmp.toString());
 


### PR DESCRIPTION
Modifies `testInvalidTempDir` in `DirectoryWatcherTest` to verify that `parent.setWritable(false)` actually takes effect before proceeding with the test.

Some file systems and operating systems do not reliably enforce directory write-permission changes (for example, common Windows/NTFS configurations for the directory owner). In such environments, the test's assumptions are invalid and can lead to false failures.

If write access cannot be revoked as expected, the test exits early instead of failing, ensuring consistent behavior across platforms while preserving test coverage where permission enforcement is supported.
