### PR TITLE
FELIX-6836: Mitigate Zip Slip / Path Traversal (CWE-22) Vulnerability in Archive Extraction and Cache Handlers

### DIFF
--- a/bundlerepository/pom.xml
+++ b/bundlerepository/pom.xml
@@ -107,8 +107,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <target>1.5</target>
-          <source>1.5</source>
+          <target>1.8</target>
+          <source>1.8</source>
         </configuration>
       </plugin>
 

--- a/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/FileUtil.java
+++ b/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/FileUtil.java
@@ -101,6 +101,8 @@ public class FileUtil
         // Reusable buffer.
         byte[] buffer = new byte[4096];
 
+        String canonicalBase = dir.getCanonicalPath();
+
         // Loop through JAR entries.
         for (JarEntry je = jis.getNextJarEntry();
              je != null;
@@ -112,6 +114,11 @@ public class FileUtil
             }
 
             File target = new File(dir, je.getName());
+            String canonicalTarget = target.getCanonicalPath();
+            if (!canonicalTarget.startsWith(canonicalBase + File.separator) && !canonicalTarget.equals(canonicalBase))
+            {
+                throw new IOException("JAR entry resolves outside the target directory: " + je.getName());
+            }
 
             // Check to see if the JAR entry is a directory.
             if (je.isDirectory())

--- a/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/ObrGogoCommand.java
+++ b/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/ObrGogoCommand.java
@@ -754,6 +754,8 @@ public class ObrGogoCommand
         // Reusable buffer.
         byte[] buffer = new byte[4096];
 
+        String canonicalBase = dir.getCanonicalPath();
+
         // Loop through JAR entries.
         for (JarEntry je = jis.getNextJarEntry();
              je != null;
@@ -765,6 +767,11 @@ public class ObrGogoCommand
             }
 
             File target = new File(dir, je.getName());
+            String canonicalTarget = target.getCanonicalPath();
+            if (!canonicalTarget.startsWith(canonicalBase + File.separator) && !canonicalTarget.equals(canonicalBase))
+            {
+                throw new IOException("JAR entry resolves outside the target directory: " + je.getName());
+            }
 
             // Check to see if the JAR entry is a directory.
             if (je.isDirectory())

--- a/bundlerepository/src/test/java/org/apache/felix/bundlerepository/impl/FileUtilTest.java
+++ b/bundlerepository/src/test/java/org/apache/felix/bundlerepository/impl/FileUtilTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.felix.bundlerepository.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
+
+import junit.framework.TestCase;
+
+public class FileUtilTest extends TestCase
+{
+    public void testUnjarZipSlip() throws Exception
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JarOutputStream jos = new JarOutputStream(baos);
+        try
+        {
+            JarEntry entry = new JarEntry("../../evil.txt");
+            jos.putNextEntry(entry);
+            jos.write("malicious content".getBytes());
+            jos.closeEntry();
+        }
+        finally
+        {
+            jos.close();
+        }
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        JarInputStream jis = new JarInputStream(bais);
+
+        File targetDir = new File("target/extraction-test-fileutil");
+        targetDir.mkdirs();
+
+        try
+        {
+            FileUtil.unjar(jis, targetDir);
+            fail("Expected IOException due to Zip Slip path traversal");
+        }
+        catch (IOException e)
+        {
+            assertTrue(e.getMessage().contains("resolves outside the target directory"));
+        }
+        finally
+        {
+            deleteDirectory(targetDir);
+        }
+    }
+
+    private void deleteDirectory(File dir)
+    {
+        File[] files = dir.listFiles();
+        if (files != null)
+        {
+            for (File f : files)
+            {
+                deleteDirectory(f);
+            }
+        }
+        dir.delete();
+    }
+}

--- a/framework/src/main/java/org/apache/felix/framework/cache/ConnectContentContent.java
+++ b/framework/src/main/java/org/apache/felix/framework/cache/ConnectContentContent.java
@@ -146,6 +146,19 @@ public class ConnectContentContent implements Content
         {
             return this;
         }
+
+        // Remove any leading slash.
+        String entryName = (name.startsWith("/")) ? name.substring(1) : name;
+
+        String normalizedEntryName = entryName.replace('\\', '/');
+        if (normalizedEntryName.trim().startsWith("../") ||
+            normalizedEntryName.contains("/../") ||
+            normalizedEntryName.trim().endsWith("/..") ||
+            normalizedEntryName.trim().equals(".."))
+        {
+            return null;
+        }
+
         String dir = name.endsWith("/") ? name : name + "/";
 
         if (hasEntry(dir))

--- a/framework/src/main/java/org/apache/felix/framework/cache/DirectoryContent.java
+++ b/framework/src/main/java/org/apache/felix/framework/cache/DirectoryContent.java
@@ -252,10 +252,11 @@ public class DirectoryContent implements Content
         // entries are relative to the root of the bundle.
         entryName = (entryName.startsWith("/")) ? entryName.substring(1) : entryName;
 
-        if (entryName.trim().startsWith(".." + File.separatorChar) ||
-                entryName.contains(File.separator + ".." + File.separatorChar) ||
-                entryName.trim().endsWith(File.separator + "..") ||
-                entryName.trim().equals(".."))
+        String normalizedEntryName = entryName.replace('\\', '/');
+        if (normalizedEntryName.trim().startsWith("../") ||
+            normalizedEntryName.contains("/../") ||
+            normalizedEntryName.trim().endsWith("/..") ||
+            normalizedEntryName.trim().equals(".."))
         {
             return null;
         }
@@ -305,10 +306,11 @@ public class DirectoryContent implements Content
         // entries are relative to the root of the bundle.
         entryName = (entryName.startsWith("/")) ? entryName.substring(1) : entryName;
 
-        if (entryName.trim().startsWith(".." + File.separatorChar) ||
-                entryName.contains(File.separator + ".." + File.separatorChar) ||
-                entryName.trim().endsWith(File.separator + "..") ||
-                entryName.trim().equals(".."))
+        String normalizedEntryName = entryName.replace('\\', '/');
+        if (normalizedEntryName.trim().startsWith("../") ||
+            normalizedEntryName.contains("/../") ||
+            normalizedEntryName.trim().endsWith("/..") ||
+            normalizedEntryName.trim().equals(".."))
         {
             return null;
         }

--- a/framework/src/main/java/org/apache/felix/framework/cache/JarContent.java
+++ b/framework/src/main/java/org/apache/felix/framework/cache/JarContent.java
@@ -241,10 +241,11 @@ public class JarContent implements Content
         // Remove any leading slash.
         entryName = (entryName.startsWith("/")) ? entryName.substring(1) : entryName;
 
-        if (entryName.trim().startsWith(".." + File.separatorChar) ||
-            entryName.contains(File.separator + ".." + File.separatorChar) ||
-            entryName.trim().endsWith(File.separator + "..") ||
-            entryName.trim().equals(".."))
+        String normalizedEntryName = entryName.replace('\\', '/');
+        if (normalizedEntryName.trim().startsWith("../") ||
+            normalizedEntryName.contains("/../") ||
+            normalizedEntryName.trim().endsWith("/..") ||
+            normalizedEntryName.trim().equals(".."))
         {
             return null;
         }
@@ -320,10 +321,11 @@ public class JarContent implements Content
         // Remove any leading slash.
         entryName = (entryName.startsWith("/")) ? entryName.substring(1) : entryName;
 
-        if (entryName.trim().startsWith(".." + File.separatorChar) ||
-            entryName.contains(File.separator + ".." + File.separatorChar) ||
-            entryName.trim().endsWith(File.separator + "..") ||
-            entryName.trim().equals(".."))
+        String normalizedEntryName = entryName.replace('\\', '/');
+        if (normalizedEntryName.trim().startsWith("../") ||
+            normalizedEntryName.contains("/../") ||
+            normalizedEntryName.trim().endsWith("/..") ||
+            normalizedEntryName.trim().equals(".."))
         {
             return null;
         }

--- a/framework/src/test/java/org/apache/felix/framework/cache/BundleCacheTest.java
+++ b/framework/src/test/java/org/apache/felix/framework/cache/BundleCacheTest.java
@@ -33,9 +33,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -45,12 +47,26 @@ import java.util.zip.ZipEntry;
 
 class BundleCacheTest
 {
+    private final List<BundleArchive> archives = new ArrayList<>();
     private File tempDir;
     private File cacheDir;
     private File filesDir;
     private BundleCache cache;
     private File archiveFile;
     private File jarFile;
+
+    private static final String SPECIAL_JAR_ENTRY = File.separatorChar == '\\'
+        ? "inner/i+~äö §$%nner.jar"
+        : "inner/i+~äö \\§$%nner.jar";
+
+    private BundleArchive track(BundleArchive archive)
+    {
+        if (archive != null)
+        {
+            archives.add(archive);
+        }
+        return archive;
+    }
 
     @BeforeEach
     void setUp() throws Exception
@@ -85,7 +101,7 @@ class BundleCacheTest
 
         new File(innerArchiveFile, "empty").mkdirs();
 
-        createJar(archiveFile, new File(archiveFile, "inner/i+?äö \\§$%nner.jar"));
+        createJar(archiveFile, new File(archiveFile, SPECIAL_JAR_ENTRY));
 
         Manifest manifest = new Manifest();
         manifest.getMainAttributes().putValue("foo", "bar");
@@ -113,21 +129,28 @@ class BundleCacheTest
 
         output.putNextEntry(new ZipEntry("../../bar.jar"));
 
-        output.write(BundleCache.read(new FileInputStream(jarFile), jarFile.length()));
+        try (FileInputStream fis = new FileInputStream(jarFile))
+        {
+            output.write(BundleCache.read(fis, jarFile.length()));
+        }
 
         output.closeEntry();
 
         output.close();
 
-        BundleArchive archive = cache.create(1, 1, "slip", new FileInputStream(bundle), null);
+        BundleArchive archive;
+        try (FileInputStream fis = new FileInputStream(bundle))
+        {
+            archive = track(cache.create(1, 1, "slip", fis, null));
+        }
 
         noZipSlip(archive);
 
-        archive = cache.create(1, 1, bundle.toURI().toURL().toString(), null, null);
+        archive = track(cache.create(1, 1, bundle.toURI().toURL().toString(), null, null));
 
         noZipSlip(archive);
 
-        archive = cache.create(1, 1, "reference:" + bundle.toURI().toURL().toString(), null, null);
+        archive = track(cache.create(1, 1, "reference:" + bundle.toURI().toURL().toString(), null, null));
 
         noZipSlip(archive);
 
@@ -139,7 +162,7 @@ class BundleCacheTest
         test.createNewFile();
         test.deleteOnExit();
 
-        archive = cache.create(1, 1, "reference:" + dir.toURI().toURL().toString(), null, null);
+        archive = track(cache.create(1, 1, "reference:" + dir.toURI().toURL().toString(), null, null));
 
         noZipSlip(archive);
     }
@@ -189,7 +212,18 @@ class BundleCacheTest
     @Test
     private BundleArchive bundle(String location, File file) throws Exception
     {
-        BundleArchive archive = cache.create(1, 1, location, file != null ? new FileInputStream(file) : null, null);
+        BundleArchive archive;
+        if (file != null)
+        {
+            try (FileInputStream fis = new FileInputStream(file))
+            {
+                archive = track(cache.create(1, 1, location, fis, null));
+            }
+        }
+        else
+        {
+            archive = track(cache.create(1, 1, location, null, null));
+        }
 
         assertThat(archive).isNotNull();
 
@@ -202,7 +236,17 @@ class BundleCacheTest
         assertThat(nativeLib).isNotNull();
         assertThat(new File(nativeLib)).isFile();
 
-        archive.revise(location, file != null ? new FileInputStream(file) : null);
+        if (file != null)
+        {
+            try (FileInputStream fis = new FileInputStream(file))
+            {
+                archive.revise(location, fis);
+            }
+        }
+        else
+        {
+            archive.revise(location, null);
+        }
 
         assertThat(archive.getCurrentRevisionNumber()).isEqualTo(1L);
 
@@ -239,12 +283,13 @@ class BundleCacheTest
         assertThat(revision).isNotNull();
         assertThat(revision.getManifestHeader()).isNotNull();
         assertThat(revision.getManifestHeader()).containsEntry("foo", "bar");
-        perRevision(revision.getContent(),  new TreeSet<>(Arrays.asList("META-INF/", "META-INF/MANIFEST.MF", "file1", "inner/", "inner/empty/", "inner/file1", "inner/i+?äö \\§$%nner.jar")));
-        perRevision(revision.getContent().getEntryAsContent("inner"),  new TreeSet<>(Arrays.asList("file1", "empty/", "i+?äö \\§$%nner.jar")));
+        String specialEntry = SPECIAL_JAR_ENTRY.replace(File.separatorChar, '/');
+        perRevision(revision.getContent(),  new TreeSet<>(Arrays.asList("META-INF/", "META-INF/MANIFEST.MF", "file1", "inner/", "inner/empty/", "inner/file1", specialEntry)));
+        perRevision(revision.getContent().getEntryAsContent("inner"),  new TreeSet<>(Arrays.asList("file1", "empty/", specialEntry.substring("inner/".length()))));
         assertThat(revision.getContent().getEntryAsContent("inner/inner")).isNull();
         assertThat(revision.getContent().getEntryAsContent("inner/empty/")).isNotNull();
         assertThat(revision.getContent().getEntryAsContent("inner/empty").getEntries()).isNull();
-        perRevision(revision.getContent().getEntryAsContent("inner/").getEntryAsContent("i+?äö \\§$%nner.jar"), new TreeSet<>(Arrays.asList("file1", "inner/", "inner/empty/", "inner/file1")));
+        perRevision(revision.getContent().getEntryAsContent("inner/").getEntryAsContent(specialEntry.substring("inner/".length())), new TreeSet<>(Arrays.asList("file1", "inner/", "inner/empty/", "inner/file1")));
     }
 
     private void perRevision(Content content, Set<String> expectedEntries) throws Exception
@@ -269,29 +314,35 @@ class BundleCacheTest
         assertThat(content.getEntryAsBytes("foo/bar")).isNull();
 
 
-        InputStream input = content.getEntryAsStream("file1");
-        assertThat(input).isNotNull();
-        entry = new byte[1014];
-        int j = 0;
-        for (int i = input.read();i != -1; i = input.read())
+        try (InputStream input = content.getEntryAsStream("file1"))
         {
-            entry[j++] = (byte) i;
+            assertThat(input).isNotNull();
+            entry = new byte[1014];
+            int j = 0;
+            for (int i = input.read();i != -1; i = input.read())
+            {
+                entry[j++] = (byte) i;
+            }
+            assertThat(new String(entry, 0, j, "UTF-8")).isEqualTo("file1");
         }
-        assertThat(new String(entry, 0, j, "UTF-8")).isEqualTo("file1");
         assertThat(content.getEntryAsStream("foo")).isNull();
         assertThat(content.getEntryAsStream("foo/bar")).isNull();
 
         URL url = content.getEntryAsURL("file1");
         assertThat(url).isNotNull();
-        input = url.openStream();
-        assertThat(input).isNotNull();
-        entry = new byte[1014];
-        j = 0;
-        for (int i = input.read();i != -1; i = input.read())
+        java.net.URLConnection conn = url.openConnection();
+        conn.setUseCaches(false);
+        try (InputStream input = conn.getInputStream())
         {
-            entry[j++] = (byte) i;
+            assertThat(input).isNotNull();
+            entry = new byte[1014];
+            int j = 0;
+            for (int i = input.read();i != -1; i = input.read())
+            {
+                entry[j++] = (byte) i;
+            }
+            assertThat(new String(entry, 0, j, "UTF-8")).isEqualTo("file1");
         }
-        assertThat(new String(entry, 0, j, "UTF-8")).isEqualTo("file1");
         assertThat(content.getEntryAsURL("foo")).isNull();
         assertThat(content.getEntryAsURL("foo/bar")).isNull();
 
@@ -304,9 +355,43 @@ class BundleCacheTest
 
     @AfterEach
     void tearDown() throws Exception {
+        for (BundleArchive archive : archives)
+        {
+            try
+            {
+                archive.close();
+            }
+            catch (Exception e)
+            {
+                // ignore
+            }
+        }
+        archives.clear();
+        cache.release();
         cache.delete();
+        if (cacheDir.exists())
+        {
+            System.out.println("--- CACHE DIR DELETION FAILED. FILES REMAINING: ---");
+            printFiles(cacheDir);
+        }
         assertThat(cacheDir.exists()).isFalse();
         assertThat(BundleCache.deleteDirectoryTree(tempDir)).isTrue();
+    }
+
+    private void printFiles(File dir)
+    {
+        File[] files = dir.listFiles();
+        if (files != null)
+        {
+            for (File f : files)
+            {
+                System.out.println(f.getAbsolutePath());
+                if (f.isDirectory())
+                {
+                    printFiles(f);
+                }
+            }
+        }
     }
 
     private void createTestArchive(File archiveFile) throws Exception
@@ -334,7 +419,10 @@ class BundleCacheTest
         JarOutputStream output;
         if (new File(source, "META-INF/MANIFEST.MF").isFile())
         {
-           output = new JarOutputStream(new FileOutputStream(tmp),new Manifest(new FileInputStream(new File(source, "META-INF/MANIFEST.MF"))));
+            try (FileInputStream fis = new FileInputStream(new File(source, "META-INF/MANIFEST.MF")))
+            {
+                output = new JarOutputStream(new FileOutputStream(tmp), new Manifest(fis));
+            }
         }
         else
         {
@@ -376,7 +464,10 @@ class BundleCacheTest
         }
         else if (current.isFile())
         {
-            output.write(BundleCache.read(new FileInputStream(current), current.length()));
+            try (FileInputStream fis = new FileInputStream(current))
+            {
+                output.write(BundleCache.read(fis, current.length()));
+            }
             output.closeEntry();
         }
     }

--- a/gogo/command/src/main/java/org/apache/felix/gogo/command/Util.java
+++ b/gogo/command/src/main/java/org/apache/felix/gogo/command/Util.java
@@ -155,6 +155,8 @@ public class Util
         // Reusable buffer.
         byte[] buffer = new byte[4096];
 
+        String canonicalBase = dir.getCanonicalPath();
+
         // Loop through JAR entries.
         for (JarEntry je = jis.getNextJarEntry();
              je != null;
@@ -166,6 +168,11 @@ public class Util
             }
 
             File target = new File(dir, je.getName());
+            String canonicalTarget = target.getCanonicalPath();
+            if (!canonicalTarget.startsWith(canonicalBase + File.separator) && !canonicalTarget.equals(canonicalBase))
+            {
+                throw new IOException("JAR entry resolves outside the target directory: " + je.getName());
+            }
 
             // Check to see if the JAR entry is a directory.
             if (je.isDirectory())

--- a/gogo/command/src/test/java/org/apache/felix/gogo/command/UtilTest.java
+++ b/gogo/command/src/test/java/org/apache/felix/gogo/command/UtilTest.java
@@ -46,4 +46,40 @@ public class UtilTest {
         u = Util.resolveUri(session, "three");
         assertEquals(new File("./three").getCanonicalFile().toURI().toString(), u);
     }
+
+    @Test
+    public void testUnjarZipSlip() throws Exception {
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        try (java.util.jar.JarOutputStream jos = new java.util.jar.JarOutputStream(baos)) {
+            java.util.jar.JarEntry entry = new java.util.jar.JarEntry("../../evil.txt");
+            jos.putNextEntry(entry);
+            jos.write("malicious content".getBytes());
+            jos.closeEntry();
+        }
+
+        java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(baos.toByteArray());
+        java.util.jar.JarInputStream jis = new java.util.jar.JarInputStream(bais);
+
+        File targetDir = new File("target/extraction-test-util");
+        targetDir.mkdirs();
+
+        try {
+            Util.unjar(jis, targetDir);
+            org.junit.Assert.fail("Expected IOException due to Zip Slip path traversal");
+        } catch (java.io.IOException e) {
+            org.junit.Assert.assertTrue(e.getMessage().contains("resolves outside the target directory"));
+        } finally {
+            deleteDirectory(targetDir);
+        }
+    }
+
+    private void deleteDirectory(File dir) {
+        File[] files = dir.listFiles();
+        if (files != null) {
+            for (File f : files) {
+                deleteDirectory(f);
+            }
+        }
+        dir.delete();
+    }
 }


### PR DESCRIPTION

This PR prevents Zip Slip / Path Traversal issues during ZIP and JAR archive extraction by validating archive entry paths before writing files to disk. Entries that would resolve outside the intended extraction directory are rejected, ensuring extraction remains confined to the target location.

In addition to the implementation changes, regression tests have been added to verify that malicious archives containing traversal entries (for example, `../../evil.txt`) are rejected and cause extraction to fail safely.
