### PR TITLE
FELIX-6845: Guard against null bundle in Log.serviceChanged()

### DIFF
--- a/log/src/main/java/org/apache/felix/log/Log.java
+++ b/log/src/main/java/org/apache/felix/log/Log.java
@@ -322,9 +322,15 @@ final class Log implements BundleListener, FrameworkListener, ServiceListener
             }
         }
 
+        final Bundle bundle = event.getServiceReference().getBundle();
+        if (bundle == null)
+        {
+            return;
+        }
+
         log(
-            "Events.Service.".concat(event.getServiceReference().getBundle().getSymbolicName()),
-            event.getServiceReference().getBundle(),
+            "Events.Service.".concat(bundle.getSymbolicName()),
+            bundle,
             event.getServiceReference(),
             (eventType == ServiceEvent.MODIFIED) ? LogLevel.DEBUG : LogLevel.INFO,
             message,


### PR DESCRIPTION
When a bundle is unregistered, ServiceReference.getBundle() may return null per the OSGi spec. Log.serviceChanged() does not guard against this, causing a NullPointerException when it attempts to call getSymbolicName() on the null bundle reference during a service unregistration race condition.

This PR adds a null check for the bundle and returns early if it is null, silently skipping the log entry for already-unregistered services.

https://issues.apache.org/jira/browse/FELIX-6845