### PR TITLE
FELIX-6848 - Update embedded Jetty to 12.1.11

### DIFF
--- a/http/base/pom.xml
+++ b/http/base/pom.xml
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.ee11.websocket</groupId>
             <artifactId>jetty-ee11-websocket-jetty-server</artifactId>
-            <version>12.1.10</version>
+            <version>12.1.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/http/jetty12/CHANGELOG.MD
+++ b/http/jetty12/CHANGELOG.MD
@@ -10,6 +10,7 @@ All notable changes to the `org.apache.felix.http.jetty12` bundle are documented
 
 ### Changed
 
+- Updated embedded Jetty to **12.1.11** (was 12.1.10). ([FELIX-6848](https://issues.apache.org/jira/browse/FELIX-6848))
 - Updated embedded Jetty to **12.1.10** (was 12.1.9). ([FELIX-6834](https://issues.apache.org/jira/browse/FELIX-6834))
 - Migrated from the deprecated `org.eclipse.jetty.server.handler.gzip.GzipHandler` to `CompressionHandler` + `GzipCompression` + `CompressionConfig` (Jetty 12.1 compression API). All include/exclude lists (methods, paths, mime types), min compress size, and sync flush are preserved. ([FELIX-6832](https://issues.apache.org/jira/browse/FELIX-6832))
 - Replaced deprecated `VirtualThreadPool.setMaxThreads` / `getMaxThreads` with `setMaxConcurrentTasks` / `getMaxConcurrentTasks`. ([FELIX-6832](https://issues.apache.org/jira/browse/FELIX-6832))

--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -42,7 +42,7 @@
 
     <properties>
         <felix.java.version>17</felix.java.version>
-        <jetty.version>12.1.10</jetty.version>
+        <jetty.version>12.1.11</jetty.version>
         <baseline.skip>true</baseline.skip>
         <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
         <!-- To debug the pax process, override this with -D -->

--- a/http/jetty12/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
+++ b/http/jetty12/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
@@ -43,7 +43,7 @@ import org.ops4j.pax.exam.options.extra.VMOption;
 import org.ops4j.pax.exam.util.PathUtils;
 
 public abstract class AbstractJettyTestSupport {
-    protected static final String JETTY_VERSION = "12.1.10";
+    protected static final String JETTY_VERSION = "12.1.11";
 
     private final String workingDirectory = String.format("%s/target/paxexam/%s/%s", PathUtils.getBaseDir(), getClass().getSimpleName(), UUID.randomUUID());
 

--- a/http/samples/whiteboard/pom.xml
+++ b/http/samples/whiteboard/pom.xml
@@ -39,7 +39,7 @@
     </scm>
 
     <properties>
-        <jetty.version>12.1.10</jetty.version>
+        <jetty.version>12.1.11</jetty.version>
     </properties>
 
     <build>


### PR DESCRIPTION
## Summary
- Bumps the embedded Jetty version used by `org.apache.felix.http.jetty12` from 12.1.10 to 12.1.11
- Updates the `JETTY_VERSION` test constant used by pax-exam integration tests to match
- Records the change in the module's CHANGELOG

Jira: [FELIX-6848](https://issues.apache.org/jira/browse/FELIX-6848)

## Test plan
- [x] `mvn -o test-compile` succeeds against the new Jetty version
- [x] `mvn -o test` unit tests pass
- [x] Verified Jetty 12.1.11 artifacts resolve from Maven Central (`mvn dependency:resolve`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)