### PR TITLE
[FELIX-6855] FileInstall prevent duplicate *.cfg files in subdirectories from corrupting live OSGi configurations

### DIFF
--- a/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/ConfigInstaller.java
+++ b/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/ConfigInstaller.java
@@ -388,6 +388,17 @@ public class ConfigInstaller implements ArtifactInstaller, ConfigurationListener
         clearReadOnlyIfWritable(pid, config, f);
 
         Dictionary<String, Object> props = config.getProperties();
+
+        // Only update if this file is the registered source of the configuration,
+        // or if no source has been registered yet (new configuration).
+        // Skips duplicate files that share the same PID but originate from a different path.
+        if (props != null) {
+            String registeredFileName = (String) props.get(DirectoryWatcher.FILENAME);
+            if (registeredFileName != null && !registeredFileName.equals(toConfigKey(f))) {
+                return false;
+            }
+        }
+
         Hashtable<String, Object> old = props != null ? new Hashtable<String, Object>(new DictionaryAsMap<>(props)) : null;
         if (old != null) {
             old.remove( DirectoryWatcher.FILENAME );
@@ -433,6 +444,17 @@ public class ConfigInstaller implements ArtifactInstaller, ConfigurationListener
     {
         String pid[] = parsePid(f.getName());
         Configuration config = getConfiguration(toConfigKey(f), pid[0], pid[1]);
+
+        // Only delete if this file is the registered source of the configuration.
+        // If the registered felix.fileinstall.filename does not match the file being deleted, skip deletion to protect the live config.
+        Dictionary<String, Object> props = config.getProperties();
+        if (props != null) {
+            String registeredFileName = (String) props.get(DirectoryWatcher.FILENAME);
+            if (registeredFileName != null && !registeredFileName.equals(toConfigKey(f))) {
+                return false;
+            }
+        }
+
         Util.log(context, Logger.LOG_INFO, "Deleting configuration {"
                 + config.getPid()
                 + "} from " + f.getAbsolutePath(), null);

--- a/fileinstall/src/test/java/org/apache/felix/fileinstall/internal/ConfigInstallerTest.java
+++ b/fileinstall/src/test/java/org/apache/felix/fileinstall/internal/ConfigInstallerTest.java
@@ -218,11 +218,133 @@ public class ConfigInstallerTest extends TestCase {
                         .andReturn(null);
         EasyMock.expect(mockConfigurationAdmin.getConfiguration("pid", "?" ))
                         .andReturn(mockConfiguration);
+        EasyMock.expect(mockConfiguration.getProperties()).andReturn(null);
         EasyMock.replay(mockConfiguration, mockConfigurationAdmin, mockBundleContext, mockBundle);
 
         ConfigInstaller ci = new ConfigInstaller( mockBundleContext, mockConfigurationAdmin, new FileInstall() );
 
         assertTrue( ci.deleteConfig( new File( "pid.cfg" ) ) );
+
+        EasyMock.verify(mockConfiguration, mockConfigurationAdmin, mockBundleContext);
+    }
+
+    // verify that deleteConfig() skips deletion when the file being deleted
+    // is a duplicate (different path) from the registered live configuration.
+    public void testDeleteConfigSkipsWhenPathDiffersFromRegisteredSource() throws Exception
+    {
+        File canonicalFile = new File( "src/test/resources/watched/firstcfg.cfg" );
+        File backupFile    = new File( "src/test/resources/watched/backup/firstcfg.cfg" );
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put( DirectoryWatcher.FILENAME, canonicalFile.getAbsoluteFile().toURI().toString() );
+
+        EasyMock.expect(mockBundleContext.getBundle()).andReturn(mockBundle).anyTimes();
+        EasyMock.expect(mockBundle.loadClass(ConfigurationAttribute.class.getName())).andReturn((Class)ConfigurationAttribute.class).anyTimes();
+        EasyMock.expect(mockBundleContext.getProperty((String) EasyMock.anyObject()))
+            .andReturn(null)
+            .anyTimes();
+        EasyMock.expect(mockConfigurationAdmin.listConfigurations((String) EasyMock.anyObject()))
+            .andReturn(null);
+        EasyMock.expect(mockConfigurationAdmin.getConfiguration("firstcfg", "?"))
+            .andReturn(mockConfiguration);
+        EasyMock.expect(mockConfiguration.getProperties()).andReturn(props);
+        EasyMock.replay(mockConfiguration, mockConfigurationAdmin, mockBundleContext, mockBundle);
+
+        ConfigInstaller ci = new ConfigInstaller( mockBundleContext, mockConfigurationAdmin, new FileInstall() );
+
+        assertFalse( ci.deleteConfig( backupFile ) );
+
+        EasyMock.verify(mockConfiguration, mockConfigurationAdmin, mockBundleContext);
+    }
+
+    // verify that deleteConfig() proceeds normally when the file being deleted
+    // is the registered source of the live configuration.
+    public void testDeleteConfigProceedsWhenPathMatchesRegisteredSource() throws Exception
+    {
+        File canonicalFile = new File( "src/test/resources/watched/firstcfg.cfg" );
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put( DirectoryWatcher.FILENAME, canonicalFile.getAbsoluteFile().toURI().toString() );
+
+        mockConfiguration.delete();
+        EasyMock.expect(mockConfiguration.getPid()).andReturn("firstcfg");
+        EasyMock.expect(mockBundleContext.getBundle()).andReturn(mockBundle).anyTimes();
+        EasyMock.expect(mockBundle.loadClass(ConfigurationAttribute.class.getName())).andReturn((Class)ConfigurationAttribute.class).anyTimes();
+        EasyMock.expect(mockBundleContext.getProperty((String) EasyMock.anyObject()))
+            .andReturn(null)
+            .anyTimes();
+        EasyMock.expect(mockConfigurationAdmin.listConfigurations((String) EasyMock.anyObject()))
+            .andReturn(null);
+        EasyMock.expect(mockConfigurationAdmin.getConfiguration("firstcfg", "?"))
+            .andReturn(mockConfiguration);
+        EasyMock.expect(mockConfiguration.getProperties()).andReturn(props);
+        EasyMock.replay(mockConfiguration, mockConfigurationAdmin, mockBundleContext, mockBundle);
+
+        ConfigInstaller ci = new ConfigInstaller( mockBundleContext, mockConfigurationAdmin, new FileInstall() );
+
+        assertTrue( ci.deleteConfig( canonicalFile ) );
+
+        EasyMock.verify(mockConfiguration, mockConfigurationAdmin, mockBundleContext);
+    }
+
+    // Verify that setConfig() skips the update when the file being set is a duplicate
+    // (different path) from the registered live configuration.
+    public void testSetConfigSkipsWhenPathDiffersFromRegisteredSource() throws Exception
+    {
+        File canonicalFile = new File( "src/test/resources/watched/firstcfg.cfg" );
+        File backupFile    = new File( "src/test/resources/watched/backup/firstcfg.cfg" );
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put( DirectoryWatcher.FILENAME, canonicalFile.getAbsoluteFile().toURI().toString() );
+
+        EasyMock.expect(mockBundleContext.getBundle()).andReturn(mockBundle).anyTimes();
+        EasyMock.expect(mockBundle.loadClass(ConfigurationAttribute.class.getName())).andReturn((Class)ConfigurationAttribute.class).anyTimes();
+        EasyMock.expect(mockBundleContext.getProperty((String) EasyMock.anyObject()))
+                .andReturn(null)
+                .anyTimes();
+        EasyMock.expect(mockConfigurationAdmin.listConfigurations((String) EasyMock.anyObject()))
+                .andReturn(null);
+        EasyMock.expect(mockConfigurationAdmin.getConfiguration("firstcfg", "?"))
+                .andReturn(mockConfiguration);
+        EasyMock.expect(mockConfiguration.getAttributes()).andReturn(Collections.emptySet()).anyTimes();
+        EasyMock.expect(mockConfiguration.getProperties()).andReturn(props);
+        EasyMock.replay(mockConfiguration, mockConfigurationAdmin, mockBundleContext, mockBundle);
+
+        ConfigInstaller ci = new ConfigInstaller( mockBundleContext, mockConfigurationAdmin, new FileInstall() );
+
+        assertFalse( ci.setConfig( backupFile ) );
+
+        EasyMock.verify(mockConfiguration, mockConfigurationAdmin, mockBundleContext);
+    }
+
+    // Verify that setConfig() proceeds normally when the file being set is the
+    // registered source of the live configuration.
+    public void testSetConfigProceedsWhenPathMatchesRegisteredSource() throws Exception
+    {
+        File canonicalFile = new File( "src/test/resources/watched/firstcfg.cfg" );
+
+        Hashtable<String, Object> props = new Hashtable<>();
+        props.put( DirectoryWatcher.FILENAME, canonicalFile.getAbsoluteFile().toURI().toString() );
+
+        EasyMock.expect(mockBundleContext.getBundle()).andReturn(mockBundle).anyTimes();
+        EasyMock.expect(mockBundle.loadClass(ConfigurationAttribute.class.getName())).andReturn((Class)ConfigurationAttribute.class).anyTimes();
+        EasyMock.expect(mockBundleContext.getProperty((String) EasyMock.anyObject()))
+            .andReturn(null)
+            .anyTimes();
+        EasyMock.expect(mockConfigurationAdmin.listConfigurations((String) EasyMock.anyObject()))
+            .andReturn(null);
+        EasyMock.expect(mockConfigurationAdmin.getConfiguration("firstcfg", "?"))
+            .andReturn(mockConfiguration);
+        EasyMock.expect(mockConfiguration.getProperties()).andReturn(props).anyTimes();
+        EasyMock.expect(mockConfiguration.getAttributes()).andReturn(Collections.emptySet()).times(2);
+        EasyMock.expect(mockConfiguration.getPid()).andReturn("firstcfg");
+        EasyMock.expect(mockConfiguration.updateIfDifferent((Dictionary<String, Object>) EasyMock.anyObject()))
+            .andReturn(true);
+        EasyMock.replay(mockConfiguration, mockConfigurationAdmin, mockBundleContext, mockBundle);
+
+        ConfigInstaller ci = new ConfigInstaller( mockBundleContext, mockConfigurationAdmin, new FileInstall() );
+
+        assertTrue( ci.setConfig( canonicalFile ) );
 
         EasyMock.verify(mockConfiguration, mockConfigurationAdmin, mockBundleContext);
     }

--- a/fileinstall/src/test/resources/watched/backup/firstcfg.cfg
+++ b/fileinstall/src/test/resources/watched/backup/firstcfg.cfg
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+testkey=testvalue


### PR DESCRIPTION
### Problem

When `felix.fileinstall.subdir.mode = recurse` is active, FileInstall scans all subdirectories under the watched root and registers every matching file as an OSGi Configuration object.

Both `setConfig()` and `deleteConfig()` derive the ConfigurationAdmin PID from the filename alone via `parsePid(f.getName())`, discarding the directory path entirely. This means any two files with the same name —
regardless of where they sit in the directory tree — resolve to the same PID.

Consequences:

- If a file with the same name as a live configuration is copied into a subdirectory, `setConfig()` overwrites the live configuration's `felix.fileinstall.filename` property with the duplicate file's URI, silently stealing ownership.

- When the duplicate file is later deleted, `deleteConfig()` resolves the same PID and calls `config.delete()` on the live Configuration object — removing it from ConfigurationAdmin even though the original physical file was never touched. Dependent OSGi services stop immediately and cannot restart.

### Fix

Before acting on a resolved Configuration object, both `setConfig()`and `deleteConfig()` now compare the absolute URI of the file under operation against the `felix.fileinstall.filename` property already stored in that Configuration.

```java
String registeredFileName = (String) props.get(DirectoryWatcher.FILENAME);
if (registeredFileName != null && !registeredFileName.equals(toConfigKey(f))) {
    return false;
}
```
## Reproduction Scenario

1. Configure `felix.fileinstall.subdir.mode = recurse` (default).
2. Let FileInstall register `/watched/etc/app.cfg` as PID `app`.
3. Copy `/watched/etc/app.cfg` to `/watched/backup/etc/app.cfg`.
4. Delete `/watched/backup/etc/app.cfg`.
5. **Before this patch:** `deleteConfig()` resolves PID `app` and removes the live configuration from ConfigurationAdmin. The service stops.
6. **After this patch:** `deleteConfig()` detects the URI mismatch and returns `false` without touching ConfigurationAdmin.