### PR TITLE
Remove obsolete SpringSource and OW2 repository dependencies

### DIFF
--- a/eventadmin/impl/src/test/java/org/apache/felix/eventadmin/ittests/AbstractTest.java
+++ b/eventadmin/impl/src/test/java/org/apache/felix/eventadmin/ittests/AbstractTest.java
@@ -17,7 +17,6 @@
 package org.apache.felix.eventadmin.ittests;
 
 import static org.junit.Assert.assertNotNull;
-import static org.ops4j.pax.exam.Constants.START_LEVEL_SYSTEM_BUNDLES;
 import static org.ops4j.pax.exam.CoreOptions.bundle;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
@@ -41,7 +40,6 @@ import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.ops4j.pax.exam.options.AbstractDelegateProvisionOption;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.event.Event;
@@ -267,9 +265,7 @@ public abstract class AbstractTest implements Runnable {
                 CoreOptions.bundle( bundleFile.toURI().toString() ),
                 mavenBundle("org.ops4j.pax.url", "pax-url-mvn", "1.3.5")
              ),
-             // below is instead of normal Pax Exam junitBundles() to deal
-             // with build server issue
-             new DirectURLJUnitBundlesOption(),
+             mavenBundle("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.junit", "4.12_1"),
              systemProperty("pax.exam.invoker").value("junit"),
              //vmOption("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005"),
              bundle("link:classpath:META-INF/links/org.ops4j.pax.exam.invoker.junit.link")
@@ -322,40 +318,4 @@ public abstract class AbstractTest implements Runnable {
     }
 
 
-    /**
-     * Clone of Pax Exam's JunitBundlesOption which uses a direct
-     * URL to the SpringSource JUnit bundle to avoid some weird
-     * repository issues on the Apache build server.
-     */
-    private static class DirectURLJUnitBundlesOption
-        extends AbstractDelegateProvisionOption<DirectURLJUnitBundlesOption> {
-
-        /**
-         * Constructor.
-         */
-        public DirectURLJUnitBundlesOption(){
-            super(
-                bundle("http://repository.springsource.com/ivy/bundles/external/org.junit/com.springsource.org.junit/4.9.0/com.springsource.org.junit-4.9.0.jar")
-            );
-            noUpdate();
-            startLevel(START_LEVEL_SYSTEM_BUNDLES);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String toString() {
-            return String.format("DirectURLJUnitBundlesOption{url=%s}", getURL());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        protected DirectURLJUnitBundlesOption itself() {
-            return this;
-        }
-
-    }
 }

--- a/eventadmin/impl/src/test/java/org/apache/felix/eventadmin/perftests/PerformanceTestIT.java
+++ b/eventadmin/impl/src/test/java/org/apache/felix/eventadmin/perftests/PerformanceTestIT.java
@@ -16,7 +16,6 @@
  */
 package org.apache.felix.eventadmin.perftests;
 
-import static org.ops4j.pax.exam.Constants.START_LEVEL_SYSTEM_BUNDLES;
 import static org.ops4j.pax.exam.CoreOptions.bundle;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
@@ -44,7 +43,6 @@ import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.ops4j.pax.exam.options.AbstractDelegateProvisionOption;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
@@ -97,9 +95,7 @@ public class PerformanceTestIT {
                         CoreOptions.bundle(bundleFile.toURI().toString()),
                         mavenBundle("org.ops4j.pax.url", "pax-url-mvn", "1.3.5")
                 ),
-                // below is instead of normal Pax Exam junitBundles() to deal
-                // with build server issue
-                new DirectURLJUnitBundlesOption(),
+                mavenBundle("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.junit", "4.12_1"),
                 systemProperty("pax.exam.invoker").value("junit"),
                 bundle("link:classpath:META-INF/links/org.ops4j.pax.exam.invoker.junit.link")
         );
@@ -302,38 +298,5 @@ public class PerformanceTestIT {
         public void unregister() {
             registration.unregister();
         }
-    }
-
-
-    private static class DirectURLJUnitBundlesOption
-            extends AbstractDelegateProvisionOption<DirectURLJUnitBundlesOption> {
-
-        /**
-         * Constructor.
-         */
-        public DirectURLJUnitBundlesOption(){
-            super(
-                    bundle("http://repository.springsource.com/ivy/bundles/external/org.junit/com.springsource.org.junit/4.9.0/com.springsource.org.junit-4.9.0.jar")
-            );
-            noUpdate();
-            startLevel(START_LEVEL_SYSTEM_BUNDLES);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String toString() {
-            return String.format("DirectURLJUnitBundlesOption{url=%s}", getURL());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        protected DirectURLJUnitBundlesOption itself() {
-            return this;
-        }
-
     }
 }

--- a/ipojo/distributions/ipojo-webconsole-quicktart/pom.xml
+++ b/ipojo/distributions/ipojo-webconsole-quicktart/pom.xml
@@ -110,14 +110,6 @@
         </dependency>
     </dependencies>
 
-    <!-- Add OW2 repository -->
-    <repositories>
-        <repository>
-            <id>ow2.releases</id>
-            <url>http://repository.ow2.org/nexus/content/groups/public/</url>
-        </repository>
-    </repositories>
-
     <build>
         <plugins>
             <plugin>

--- a/ipojo/distributions/ipojo-webconsole-quicktart/pom.xml
+++ b/ipojo/distributions/ipojo-webconsole-quicktart/pom.xml
@@ -90,8 +90,8 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>com.springsource.javax.servlet</artifactId>
-            <version>2.4.0</version>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -115,12 +115,6 @@
         <repository>
             <id>ow2.releases</id>
             <url>http://repository.ow2.org/nexus/content/groups/public/</url>
-        </repository>
-
-        <repository>
-            <id>com.springsource.repository.libraries.external</id>
-            <name>SpringSource Enterprise Bundle Repository - External Library Releases</name>
-            <url>http://repository.springsource.com/maven/bundles/external</url>
         </repository>
     </repositories>
 

--- a/ipojo/distributions/ipojo-webconsole-quicktart/pom.xml
+++ b/ipojo/distributions/ipojo-webconsole-quicktart/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.ipojo.webconsole</artifactId>
-            <version>1.7.0-SNAPSHOT</version>
+            <version>1.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/ipojo/distributions/ipojo-webconsole-quicktart/src/main/assembly/distribution.xml
+++ b/ipojo/distributions/ipojo-webconsole-quicktart/src/main/assembly/distribution.xml
@@ -47,7 +47,6 @@
                 <include>*:org.apache.felix.*:jar</include>
                 <include>javax.servlet:javax.servlet-api:*</include>
                 <include>org.osgi:org.osgi.compendium:*</include>
-                <include>org.json:org.ow2.chameleon.commons.json:*</include>
                 <include>commons-io:commons-io:*</include>
                 <include>commons-fileupload:*:*</include>
             </includes>

--- a/ipojo/distributions/ipojo-webconsole-quicktart/src/main/assembly/distribution.xml
+++ b/ipojo/distributions/ipojo-webconsole-quicktart/src/main/assembly/distribution.xml
@@ -45,7 +45,7 @@
         <dependencySet>
             <includes>
                 <include>*:org.apache.felix.*:jar</include>
-                <include>javax.servlet:com.springsource.javax.servlet:*</include>
+                <include>javax.servlet:javax.servlet-api:*</include>
                 <include>org.osgi:org.osgi.compendium:*</include>
                 <include>org.json:org.ow2.chameleon.commons.json:*</include>
                 <include>commons-io:commons-io:*</include>

--- a/ipojo/handler/jmx/jmx-handler-it/src/it/jmx-it/src/test/java/org/apache/felix/ipojo/handler/jmx/test/Common.java
+++ b/ipojo/handler/jmx/jmx-handler-it/src/it/jmx-it/src/test/java/org/apache/felix/ipojo/handler/jmx/test/Common.java
@@ -27,7 +27,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
-import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.options.CompositeOption;
@@ -87,12 +86,7 @@ public class Common {
 
     public static Option junitAndMockitoBundles() {
         return new DefaultCompositeOption(
-                // Repository required to load harmcrest (OSGi-fied version).
-                repository("http://repository.springsource.com/maven/bundles/external").id(
-                        "com.springsource.repository.bundles.external"),
-
-                // Hamcrest with a version matching the range expected by Mockito
-                mavenBundle("org.hamcrest", "com.springsource.org.hamcrest.core", "1.1.0"),
+                mavenBundle("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.junit", "4.11_2"),
 
                 // Mockito core does not includes Hamcrest
                 mavenBundle("org.mockito", "mockito-core", "1.9.5"),
@@ -100,11 +94,6 @@ public class Common {
                 // Objenesis with a version matching the range expected by Mockito
                 wrappedBundle(mavenBundle("org.objenesis", "objenesis", "1.2"))
                         .exports("*;version=1.2"),
-
-                // The default JUnit bundle also exports Hamcrest, but with an (incorrect) version of
-                // 4.9 which does not match the Mockito import. When deployed after the hamcrest bundles, it gets
-                // resolved correctly.
-                CoreOptions.junitBundles(),
 
                 /*
                  * Felix has implicit boot delegation enabled by default. It conflicts with Mockito:

--- a/ipojo/handler/transaction/transaction-handler-it/src/it/transaction-it/src/test/java/org/apache/felix/ipojo/handler/transaction/test/Common.java
+++ b/ipojo/handler/transaction/transaction-handler-it/src/it/transaction-it/src/test/java/org/apache/felix/ipojo/handler/transaction/test/Common.java
@@ -27,7 +27,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
-import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.options.CompositeOption;
@@ -70,12 +69,7 @@ public class Common {
 
     public static Option junitAndMockitoBundles() {
         return new DefaultCompositeOption(
-                // Repository required to load harmcrest (OSGi-fied version).
-                repository("http://repository.springsource.com/maven/bundles/external").id(
-                        "com.springsource.repository.bundles.external"),
-
-                // Hamcrest with a version matching the range expected by Mockito
-                mavenBundle("org.hamcrest", "com.springsource.org.hamcrest.core", "1.1.0"),
+                mavenBundle("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.junit", "4.11_2"),
 
                 // Mockito core does not includes Hamcrest
                 mavenBundle("org.mockito", "mockito-core", "1.9.5"),
@@ -83,11 +77,6 @@ public class Common {
                 // Objenesis with a version matching the range expected by Mockito
                 wrappedBundle(mavenBundle("org.objenesis", "objenesis", "1.2"))
                         .exports("*;version=1.2"),
-
-                // The default JUnit bundle also exports Hamcrest, but with an (incorrect) version of
-                // 4.9 which does not match the Mockito import. When deployed after the hamcrest bundles, it gets
-                // resolved correctly.
-                CoreOptions.junitBundles(),
 
                 /*
                  * Felix has implicit boot delegation enabled by default. It conflicts with Mockito:

--- a/ipojo/handler/whiteboard/whiteboard-handler-it/src/it/whiteboard-it/src/test/java/org/apache/felix/ipojo/handler/whiteboard/test/Common.java
+++ b/ipojo/handler/whiteboard/whiteboard-handler-it/src/it/whiteboard-it/src/test/java/org/apache/felix/ipojo/handler/whiteboard/test/Common.java
@@ -27,7 +27,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
-import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.options.CompositeOption;
@@ -87,12 +86,7 @@ public class Common {
 
     public static Option junitAndMockitoBundles() {
         return new DefaultCompositeOption(
-                // Repository required to load harmcrest (OSGi-fied version).
-                repository("http://repository.springsource.com/maven/bundles/external").id(
-                        "com.springsource.repository.bundles.external"),
-
-                // Hamcrest with a version matching the range expected by Mockito
-                mavenBundle("org.hamcrest", "com.springsource.org.hamcrest.core", "1.1.0"),
+                mavenBundle("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.junit", "4.11_2"),
 
                 // Mockito core does not includes Hamcrest
                 mavenBundle("org.mockito", "mockito-core", "1.9.5"),
@@ -100,11 +94,6 @@ public class Common {
                 // Objenesis with a version matching the range expected by Mockito
                 wrappedBundle(mavenBundle("org.objenesis", "objenesis", "1.2"))
                         .exports("*;version=1.2"),
-
-                // The default JUnit bundle also exports Hamcrest, but with an (incorrect) version of
-                // 4.9 which does not match the Mockito import. When deployed after the hamcrest bundles, it gets
-                // resolved correctly.
-                CoreOptions.junitBundles(),
 
                 /*
                  * Felix has implicit boot delegation enabled by default. It conflicts with Mockito:


### PR DESCRIPTION
## Summary

- replace Event Admin's hard-coded SpringSource JUnit bundle with the ServiceMix JUnit 4.12 bundle expected by Pax Exam 4.13.1
- replace the remaining iPOJO SpringSource JUnit/Hamcrest workarounds with a ServiceMix JUnit 4.11 bundle matching Pax Exam 3.0.0
- replace the quickstart's SpringSource Servlet bundle with the OSGi-enabled javax.servlet-api 4.0.1 artifact from Maven Central
- remove the orphaned OW2 repository and stale Chameleon JSON assembly include
- use the released iPOJO Web Console plugin 1.7.0 instead of the unavailable 1.7.0-SNAPSHOT

## Verification

- `JAVA_HOME=/opt/jdks/latest-8 mvn -f eventadmin/impl/pom.xml clean verify`
  - 8 unit tests passed
  - Pax Exam stress integration test passed, processing 1,050,000 events
- `JAVA_HOME=/opt/jdks/latest-8 mvn -f ipojo/distributions/ipojo-webconsole-quicktart/pom.xml clean verify`
  - build succeeded
  - ZIP and tar.gz distributions were generated
- verified the replacement Servlet and ServiceMix artifacts resolve from Maven Central and contain OSGi bundle metadata

## Notes

The legacy iPOJO handler integration-test reactors do not currently reach their tests: their missing bundle-plugin version selects maven-bundle-plugin 6.1.0, which requires Java 17, while these projects target Java 5/6. The affected helper methods are not referenced by the current test configurations.

Event Admin verification on Java 17 also encounters a legacy Bnd 4.2.1 ConcurrentModificationException during packaging; the full Java 8 build passes.
