### PR TITLE
FELIX-6857 maven-bundle-plugin: do not embed type=pom dependencies

### DIFF
--- a/tools/maven-bundle-plugin/src/it/embed-pom-dependency/pom.xml
+++ b/tools/maven-bundle-plugin/src/it/embed-pom-dependency/pom.xml
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!--
+  FELIX-6857: a pom-type dependency (BOM/aggregator) resolves to a .pom file and contains no
+  classes. It must not be embedded, otherwise the .pom ends up on the bundle classpath and bnd
+  (7.3.0+) fails trying to open it as a JAR. Here junit-bom is a type=pom dependency alongside a
+  regular jar dependency; only the jar must be embedded.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.felix.bundleits</groupId>
+  <artifactId>embed-pom-dependency</artifactId>
+  <version>1-SNAPSHOT</version>
+  <packaging>bundle</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit</groupId>
+      <artifactId>junit-bom</artifactId>
+      <version>5.11.3</version>
+      <type>pom</type>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Embed-Dependency>*;scope=compile</Embed-Dependency>
+            <Import-Package>*;resolution:=optional</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tools/maven-bundle-plugin/src/it/embed-pom-dependency/verify.groovy
+++ b/tools/maven-bundle-plugin/src/it/embed-pom-dependency/verify.groovy
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// FELIX-6857: reaching this script means the build succeeded (before the fix, embedding the
+// junit-bom .pom made bnd fail the build). Assert the pom was excluded but the jar was embedded.
+
+import java.util.jar.Manifest
+
+File manifestFile = new File(basedir, "target/classes/META-INF/MANIFEST.MF")
+assert manifestFile.exists() : "MANIFEST.MF was not generated"
+
+Manifest manifest = manifestFile.withInputStream { new Manifest(it) }
+def attributes = manifest.getMainAttributes()
+
+String bundleClassPath = attributes.getValue("Bundle-ClassPath") ?: ""
+String embeddedArtifacts = attributes.getValue("Embedded-Artifacts") ?: ""
+
+// the pom dependency must never be embedded
+assert !bundleClassPath.contains("junit-bom") : "pom dependency leaked onto Bundle-ClassPath: " + bundleClassPath
+assert !bundleClassPath.contains(".pom") : "a .pom leaked onto Bundle-ClassPath: " + bundleClassPath
+assert !embeddedArtifacts.contains("junit-bom") : "pom dependency was embedded: " + embeddedArtifacts
+
+// the regular jar dependency must still be embedded
+assert bundleClassPath.contains("commons-io") : "expected commons-io jar to be embedded, Bundle-ClassPath: " + bundleClassPath
+
+return true

--- a/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/DependencyEmbedder.java
+++ b/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/DependencyEmbedder.java
@@ -52,6 +52,8 @@ public final class DependencyEmbedder extends AbstractDependencyFilter
     private String m_embedStripGroup;
     private String m_embedStripVersion;
 
+    private final Log m_log;
+
     /**
      * Inlined paths.
      */
@@ -67,6 +69,7 @@ public final class DependencyEmbedder extends AbstractDependencyFilter
     {
         super( dependencyArtifacts );
 
+        m_log = log;
         m_inlinedPaths = new LinkedHashSet<>();
         m_embeddedArtifacts = new LinkedHashSet<>();
     }
@@ -119,15 +122,43 @@ public final class DependencyEmbedder extends AbstractDependencyFilter
     {
         if ( null == inline || "false".equalsIgnoreCase( inline ) )
         {
-            m_embeddedArtifacts.addAll( dependencies );
+            for ( Artifact dependency : dependencies )
+            {
+                if ( isPomArtifact( dependency ) )
+                {
+                    continue;
+                }
+                m_embeddedArtifacts.add( dependency );
+            }
         }
         else
         {
             for ( Artifact dependency : dependencies )
             {
+                if ( isPomArtifact( dependency ) )
+                {
+                    continue;
+                }
                 addInlinedPaths( dependency, inline, m_inlinedPaths );
             }
         }
+    }
+
+
+    /**
+     * A {@code pom} dependency (a BOM/aggregator) resolves to a {@code .pom} file and contains no classes.
+     * Embedding it would place the {@code .pom} on the bundle classpath, which bnd then fails to open as a
+     * JAR. Such artifacts must never be embedded, so they are skipped here with a warning.
+     */
+    private boolean isPomArtifact( Artifact dependency )
+    {
+        if ( "pom".equals( dependency.getType() ) )
+        {
+            m_log.warn( "Not embedding pom dependency " + dependency.getId()
+                + "; pom artifacts contain no classes and cannot be placed on the bundle classpath" );
+            return true;
+        }
+        return false;
     }
 
 

--- a/tools/maven-bundle-plugin/src/test/java/org/apache/felix/bundleplugin/BundlePluginTest.java
+++ b/tools/maven-bundle-plugin/src/test/java/org/apache/felix/bundleplugin/BundlePluginTest.java
@@ -37,6 +37,7 @@ import java.util.TreeMap;
 import java.util.jar.Manifest;
 
 import org.apache.felix.bundleplugin.BundlePlugin.ClassPathItem;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Organization;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.apache.maven.project.MavenProject;
@@ -249,6 +250,35 @@ public class BundlePluginTest extends AbstractBundlePluginTest
         String eas = manifest.getMainAttributes().getValue( "Embedded-Artifacts" );
         assertEquals( "compile-1.0.jar;g=\"g\";a=\"compile\";v=\"1.0\"," + "b-1.0.jar;g=\"g\";a=\"b\";v=\"1.0\","
             + "runtime-1.0.jar;g=\"g\";a=\"runtime\";v=\"1.0\"", eas );
+    }
+
+
+    public void testEmbedDependencyExcludesPomArtifacts() throws Exception
+    {
+        // FELIX-6857: a pom-type dependency (BOM/aggregator) resolves to a .pom file with no classes;
+        // it must never be embedded, otherwise the .pom ends up on the bundle classpath and bnd fails
+        // trying to open it as a JAR.
+        ArtifactStubFactory artifactFactory = new ArtifactStubFactory( plugin.getOutputDirectory(), true );
+
+        Set artifacts = new LinkedHashSet();
+        artifacts.add( artifactFactory.createArtifact( "g", "jardep", "1.0", Artifact.SCOPE_COMPILE, "jar", null ) );
+        artifacts.add( artifactFactory.createArtifact( "g", "pomdep", "1.0", Artifact.SCOPE_COMPILE, "pom", null ) );
+
+        MavenProject project = getMavenProjectStub();
+        project.setDependencyArtifacts( artifacts );
+
+        Map instructions = new HashMap();
+        instructions.put( DependencyEmbedder.EMBED_DEPENDENCY, "*;scope=compile" );
+
+        Builder builder = plugin.buildOSGiBundle( project, instructions, plugin.getClasspath( project ) );
+        Manifest manifest = builder.getJar().getManifest();
+
+        // only the jar is embedded; the pom is excluded from both Bundle-ClassPath and Embedded-Artifacts
+        String bcp = manifest.getMainAttributes().getValue( Constants.BUNDLE_CLASSPATH );
+        assertEquals( ".,jardep-1.0.jar", bcp );
+
+        String eas = manifest.getMainAttributes().getValue( "Embedded-Artifacts" );
+        assertEquals( "jardep-1.0.jar;g=\"g\";a=\"jardep\";v=\"1.0\"", eas );
     }
 
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FELIX-6857

## Problem

When a bundle uses `Embed-Dependency` and one of the selected dependencies is a
`type=pom` artifact (a BOM/aggregator declared as a compile dependency),
`DependencyEmbedder` adds that artifact's `.pom` file to the bundle classpath
(`Bundle-ClassPath` / `-includeresource`). bnd's CDI-annotations analyzer then tries
to open the `.pom` as a JAR/ZIP and fails:

- **maven-bundle-plugin 6.0.2** (embeds bnd 7.0.0): emits `[WARNING] Invalid bundle
  classpath entry` and **builds successfully**.
- **maven-bundle-plugin 6.1.0** (embeds bnd 7.3.0): the same condition is now a fatal
  `[ERROR] Error(s) found in bundle configuration` and **fails the build**.

So upgrading the plugin breaks any bundle that embeds a pom-type dependency.

```
[ERROR] Bundle ... : Analyzer Plugin CDIAnnotations failed The JAR/ZIP file
(.../org/junit/junit-bom/5.11.3/junit-bom-5.11.3.pom) seems corrupted,
error: zip END header not found -> zip END header not found for AnalyzerPlugin
[ERROR] Error(s) found in bundle configuration
```


The `.pom` is valid XML, not corrupt — bnd is simply being handed a pom to open as an
archive.

## Root cause

`DependencyEmbedder` embeds any selected artifact whose file exists, without checking
its type, so a `type=pom` dependency's `.pom` file ends up on the classpath. A pom
contains no classes and must never be on the bundle classpath.

The underlying hard-fail is a bnd 7.0.0 → 7.3.0 behaviour change in
`aQute.bnd.cdi.CDIAnnotations#analyzeJar` (a warning promoted to a fatal error), but the
plugin should never have placed the `.pom` there in the first place.

## Fix

Skip `type=pom` artifacts in `DependencyEmbedder`, covering both the embed and inline
paths, logging a warning so it is not silent. The non-embed classpath path in
`BundlePlugin.getClasspath()` already excludes poms via
`ArtifactHandler.isAddedToClasspath()`, so only the embed path needed the guard.

## Reproducer

```xml
<packaging>bundle</packaging>
<dependencies>
  <dependency>
    <groupId>org.junit</groupId>
    <artifactId>junit-bom</artifactId>
    <version>5.11.3</version>
    <type>pom</type>
  </dependency>
</dependencies>
```
`<Embed-Dependency>*;scope=compile</Embed-Dependency>`

mvn clean package fails on 6.1.0, succeeds on 6.0.2 (and with this fix).

## Testing

Added BundlePluginTest#testEmbedDependencyExcludesPomArtifacts, asserting a pom
dependency is excluded from Bundle-ClassPath and Embedded-Artifacts while a
regular jar is still embedded. Fails without the fix, passes with it.
Added an embed-pom-dependency integration test (a type=pom dependency alongside a
jar dependency). The build fails without the fix (the CDIAnnotations error above) and
passes with it.