### PR TITLE
FELIX-6858 Upgrade bndlib to 7.4.0

### DIFF
--- a/tools/maven-bundle-plugin/README.md
+++ b/tools/maven-bundle-plugin/README.md
@@ -2,7 +2,7 @@ Maven-bundle-plugin
 
 # Upgrade notice
 
-* 6.1.3 uses bnd 7.4.0, which keeps java 17 as minimal java version.
+* 6.1.4 uses bnd 7.4.0, which keeps java 17 as minimal java version.
   * see https://github.com/bndtools/bnd/wiki/Changes-in-7.4.0 for more information.
 * 6.1.0 uses bnd 7.3.0, which keeps java 17 as minimal java version.
   * see https://github.com/bndtools/bnd/wiki/Changes-in-7.3.0 for more information.

--- a/tools/maven-bundle-plugin/README.md
+++ b/tools/maven-bundle-plugin/README.md
@@ -2,6 +2,8 @@ Maven-bundle-plugin
 
 # Upgrade notice
 
+* 6.1.3 uses bnd 7.4.0, which keeps java 17 as minimal java version.
+  * see https://github.com/bndtools/bnd/wiki/Changes-in-7.4.0 for more information.
 * 6.1.0 uses bnd 7.3.0, which keeps java 17 as minimal java version.
   * see https://github.com/bndtools/bnd/wiki/Changes-in-7.3.0 for more information.
 * 6.0.0 uses bnd 7.0.0, which has java 17 as minimal java version.

--- a/tools/maven-bundle-plugin/changelog.txt
+++ b/tools/maven-bundle-plugin/changelog.txt
@@ -1,4 +1,4 @@
-Changes from 6.1.2 to 6.1.3
+Changes from 6.1.2 to 6.1.4
 ---------------------------
 * Improvement
     * [FELIX-6858] - Upgrade bndlib to 7.4.0. See https://github.com/bndtools/bnd/wiki/Changes-in-7.4.0

--- a/tools/maven-bundle-plugin/changelog.txt
+++ b/tools/maven-bundle-plugin/changelog.txt
@@ -1,3 +1,8 @@
+Changes from 6.1.2 to 6.1.3
+---------------------------
+* Improvement
+    * [FELIX-6858] - Upgrade bndlib to 7.4.0. See https://github.com/bndtools/bnd/wiki/Changes-in-7.4.0
+
 Changes from 6.1.0 to 6.1.2
 ---------------------------
 * Bug

--- a/tools/maven-bundle-plugin/pom.xml
+++ b/tools/maven-bundle-plugin/pom.xml
@@ -179,7 +179,7 @@
   <dependency>
     <groupId>biz.aQute.bnd</groupId>
     <artifactId>biz.aQute.bndlib</artifactId>
-    <version>7.3.0</version>
+    <version>7.4.0</version>
   </dependency>
   <dependency>
     <groupId>org.slf4j</groupId>

--- a/tools/maven-bundle-plugin/src/it/with-multi-release-jar/verify.groovy
+++ b/tools/maven-bundle-plugin/src/it/with-multi-release-jar/verify.groovy
@@ -20,7 +20,7 @@ String manifest = new File( basedir, "target/classes/META-INF/MANIFEST.MF" ).tex
 assert !manifest.isEmpty()
 
 manifest.eachLine() { line ->
-    if (line.contains("Tool") && !line.contains("7.3.0")) {
+    if (line.contains("Tool") && !line.contains("7.4.0")) {
         throw new Exception("Wrong bnd version used");
     }
     if (line.contains("Embedded-Artifacts") && !line.contains("jersey-server-3.1.7.jar")) {


### PR DESCRIPTION
Upgrades `biz.aQute.bndlib` from 7.3.0 to 7.4.0 in maven-bundle-plugin.

See https://github.com/bndtools/bnd/wiki/Changes-in-7.4.0

## Changes
- `pom.xml`: `biz.aQute.bndlib` 7.3.0 → 7.4.0
- `src/it/with-multi-release-jar/verify.groovy`: assert the Bnd `Tool` header is 7.4.0
- `README.md` upgrade notice and `changelog.txt` updated

## Verification
- `mvn verify` → BUILD SUCCESS
- All 11 integration tests pass (including the `Tool` version assertion and `unversioned-export-package-still-imported`)

JIRA: https://issues.apache.org/jira/browse/FELIX-6858

🤖 Generated with [Claude Code](https://claude.com/claude-code)