### PR TITLE
FELIX-6830 Do not include alien classpath resources when a module-info is present

### DIFF
--- a/tools/maven-bundle-plugin/README.md
+++ b/tools/maven-bundle-plugin/README.md
@@ -2,7 +2,7 @@ Maven-bundle-plugin
 
 # Upgrade notice
 
-* 6.1.4 uses bnd 7.4.0, which keeps java 17 as minimal java version.
+* 6.2.0 uses bnd 7.4.0, which keeps java 17 as minimal java version.
   * see https://github.com/bndtools/bnd/wiki/Changes-in-7.4.0 for more information.
 * 6.1.0 uses bnd 7.3.0, which keeps java 17 as minimal java version.
   * see https://github.com/bndtools/bnd/wiki/Changes-in-7.3.0 for more information.

--- a/tools/maven-bundle-plugin/changelog.txt
+++ b/tools/maven-bundle-plugin/changelog.txt
@@ -1,3 +1,8 @@
+Changes from 6.1.2 to 6.1.4
+---------------------------
+* Bug
+    * [FELIX-6830] - maven-bundle-plugin includes alien resources (e.g. beans_*.xsd, validation-*.xsd) from classpath dependencies when a module-info is present
+
 Changes from 6.1.0 to 6.1.2
 ---------------------------
 * Bug

--- a/tools/maven-bundle-plugin/changelog.txt
+++ b/tools/maven-bundle-plugin/changelog.txt
@@ -1,4 +1,4 @@
-Changes from 6.1.2 to 6.1.4
+Changes from 6.1.2 to 6.2.0
 ---------------------------
 * Bug
     * [FELIX-6830] - maven-bundle-plugin includes alien resources (e.g. beans_*.xsd, validation-*.xsd) from classpath dependencies when a module-info is present

--- a/tools/maven-bundle-plugin/src/it/module-info-no-alien-resources/pom.xml
+++ b/tools/maven-bundle-plugin/src/it/module-info-no-alien-resources/pom.xml
@@ -1,0 +1,61 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!--
+  FELIX-6830: when a project ships a module-info.java, its compiled module-info.class lands in the
+  default (root) package. The plugin used to add the default package "." to Private-Package, which
+  made bnd copy the default package of every classpath jar into the bundle - dragging in alien
+  root-level resources such as the beans_*.xsd files bundled at the root of jakarta.enterprise.cdi-api.
+  The module descriptor itself must still end up in the bundle.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.felix.bundleits</groupId>
+  <artifactId>module-info-no-alien-resources</artifactId>
+  <version>1-SNAPSHOT</version>
+  <packaging>bundle</packaging>
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <!-- carries beans_1_0.xsd .. beans_4_0.xsd at the JAR root (the default package) -->
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+      <version>4.0.1</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>*;resolution:=optional</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tools/maven-bundle-plugin/src/it/module-info-no-alien-resources/src/main/java/module-info.java
+++ b/tools/maven-bundle-plugin/src/it/module-info-no-alien-resources/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.felix.bundleits.moduleinfo {
+    exports org.apache.felix.bundleits.moduleinfo;
+}

--- a/tools/maven-bundle-plugin/src/it/module-info-no-alien-resources/src/main/java/org/apache/felix/bundleits/moduleinfo/Sample.java
+++ b/tools/maven-bundle-plugin/src/it/module-info-no-alien-resources/src/main/java/org/apache/felix/bundleits/moduleinfo/Sample.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.felix.bundleits.moduleinfo;
+
+public final class Sample {
+    private Sample() {
+    }
+}

--- a/tools/maven-bundle-plugin/src/it/module-info-no-alien-resources/verify.groovy
+++ b/tools/maven-bundle-plugin/src/it/module-info-no-alien-resources/verify.groovy
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import java.util.zip.ZipFile
+
+File bundle = new File( basedir, "target/module-info-no-alien-resources-1-SNAPSHOT.jar" )
+assert bundle.exists() : "bundle was not built: " + bundle
+
+List<String> names = new ZipFile( bundle ).withCloseable { zip ->
+    zip.entries().collect { it.name }
+}
+
+// the module descriptor must still be packaged
+assert names.contains( "module-info.class" ) : "module-info.class is missing from the bundle: " + names
+
+// the project's own class must be packaged
+assert names.contains( "org/apache/felix/bundleits/moduleinfo/Sample.class" ) : "own class missing from the bundle: " + names
+
+// alien root-level resources from classpath dependencies (e.g. beans_*.xsd from cdi-api) must NOT leak in
+List<String> alien = names.findAll { it.toLowerCase().endsWith( ".xsd" ) }
+assert alien.isEmpty() : "alien resources leaked into the bundle: " + alien

--- a/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
+++ b/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
@@ -1936,6 +1936,13 @@ public class BundlePlugin extends AbstractMojo
             scanner.setBasedir( outputDirectory );
             scanner.setIncludes( new String[]
                 { "**/*.class" } );
+            // FELIX-6830: module-info.class lives in the default (root) package. If it were counted
+            // as a local package, the default package "." would be added to Private-Package and bnd
+            // would then copy the default package of every classpath jar into the bundle, dragging in
+            // alien root-level resources (e.g. the beans_*.xsd files at the root of jakarta.enterprise.cdi-api).
+            // The module descriptor is re-added as an explicit resource below.
+            scanner.setExcludes( new String[]
+                { "**/module-info.class" } );
 
             scanner.addDefaultExcludes();
             scanner.scan();
@@ -2012,6 +2019,28 @@ public class BundlePlugin extends AbstractMojo
         {
             String newInternal = StringUtils.replace( internal, LOCAL_PACKAGES, Processor.printClauses( privatePkgs ) );
             properties.setProperty( Analyzer.PRIVATE_PACKAGE, newInternal );
+        }
+
+        // FELIX-6830: the module descriptor was deliberately left out of the package scan above (it is not a
+        // real package). Add it back as an explicit resource so the bundle keeps its module-info.class without
+        // the default package - and its alien classpath resources - being copied in.
+        if ( outputDirectory != null )
+        {
+            File moduleInfo = new File( outputDirectory, "module-info.class" );
+            if ( moduleInfo.isFile() )
+            {
+                String resourcePath = moduleInfo.getAbsolutePath().replace( File.separatorChar, '/' );
+                String clause = "module-info.class=" + resourcePath;
+                String includeResource = properties.getProperty( Analyzer.INCLUDE_RESOURCE );
+                if ( includeResource == null || includeResource.isEmpty() )
+                {
+                    properties.setProperty( Analyzer.INCLUDE_RESOURCE, clause );
+                }
+                else if ( !includeResource.contains( "module-info.class" ) )
+                {
+                    properties.setProperty( Analyzer.INCLUDE_RESOURCE, includeResource + ',' + clause );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes the inclusion of unrelated (alien) root-level resources from classpath dependencies when a project ships a `module-info.java`.

JIRA: https://issues.apache.org/jira/browse/FELIX-6830
Reported via: https://github.com/jakartaee/mvc/pull/73#issuecomment-2934163673

## Root cause
A project's `module-info.class` is compiled into the **default (root) package** of the output directory. `addLocalPackages()` scans `**/*.class`, so it added the default package `.` to `Private-Package`. When bnd expands that package it copies the default (root) package of **every** jar on the bnd classpath into the bundle, dragging in unrelated root-level resources — e.g. the `beans_*.xsd` files at the root of `jakarta.enterprise.cdi-api` and the `validation-*.xsd` files at the root of `jakarta.validation-api`.

Without a `module-info`, nothing lives in the root package, so `.` is never added and the copy never happens.

## Fix
- Exclude `module-info.class` from the local package scan, so the default package is no longer treated as a private package.
- Re-add `module-info.class` as an explicit `Include-Resource`, so the bundle keeps its module descriptor without pulling in the alien resources.

## Verification
- New integration test `module-info-no-alien-resources` (module-info + `jakarta.enterprise.cdi-api`) asserts the `beans_*.xsd` do **not** leak in, while `module-info.class` and the project's own classes are retained. It fails before the fix and passes after.
- `mvn verify` → BUILD SUCCESS, 12/12 integration tests pass, RAT clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)