### PR TITLE
FELIX-6860 Update embedded Jetty to 12.1.13

### DIFF
--- a/http/base/pom.xml
+++ b/http/base/pom.xml
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.ee11.websocket</groupId>
             <artifactId>jetty-ee11-websocket-jetty-server</artifactId>
-            <version>12.1.12</version>
+            <version>12.1.13</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/http/jetty12/CHANGELOG.MD
+++ b/http/jetty12/CHANGELOG.MD
@@ -10,6 +10,7 @@ All notable changes to the `org.apache.felix.http.jetty12` bundle are documented
 
 ### Changed
 
+- Updated embedded Jetty to **12.1.13** (was 12.1.12). ([FELIX-6860](https://issues.apache.org/jira/browse/FELIX-6860))
 - Updated embedded Jetty to **12.1.12** (was 12.1.11). ([FELIX-6856](https://issues.apache.org/jira/browse/FELIX-6856))
 - Updated embedded Jetty to **12.1.11** (was 12.1.10). ([FELIX-6848](https://issues.apache.org/jira/browse/FELIX-6848))
 - Updated embedded Jetty to **12.1.10** (was 12.1.9). ([FELIX-6834](https://issues.apache.org/jira/browse/FELIX-6834))

--- a/http/jetty12/pom.xml
+++ b/http/jetty12/pom.xml
@@ -45,7 +45,7 @@
              The optional virtual-threads support (felix.jetty.threadpool.useVirtualThreads)
              additionally requires Java 21 at runtime and is enabled conditionally (see JettyService). -->
         <felix.java.version>17</felix.java.version>
-        <jetty.version>12.1.12</jetty.version>
+        <jetty.version>12.1.13</jetty.version>
         <slf4j.version>2.0.17</slf4j.version>
         <baseline.skip>false</baseline.skip>
         <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>

--- a/http/jetty12/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
+++ b/http/jetty12/src/test/java/org/apache/felix/http/jetty/it/AbstractJettyTestSupport.java
@@ -43,7 +43,7 @@ import org.ops4j.pax.exam.options.extra.VMOption;
 import org.ops4j.pax.exam.util.PathUtils;
 
 public abstract class AbstractJettyTestSupport {
-    protected static final String JETTY_VERSION = "12.1.12";
+    protected static final String JETTY_VERSION = "12.1.13";
 
     private final String workingDirectory = String.format("%s/target/paxexam/%s/%s", PathUtils.getBaseDir(), getClass().getSimpleName(), UUID.randomUUID());
 

--- a/http/samples/whiteboard/pom.xml
+++ b/http/samples/whiteboard/pom.xml
@@ -39,7 +39,7 @@
     </scm>
 
     <properties>
-        <jetty.version>12.1.12</jetty.version>
+        <jetty.version>12.1.13</jetty.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Updates the embedded Jetty in the `org.apache.felix.http.jetty12` bundle from 12.1.12 to [12.1.13](https://github.com/jetty/jetty.project/releases/tag/jetty-12.1.13).

- `http/jetty12/pom.xml`: `jetty.version` 12.1.12 → 12.1.13
- `http/base/pom.xml`: test-scoped `jetty-ee11-websocket-jetty-server` 12.1.12 → 12.1.13
- `http/samples/whiteboard/pom.xml`: `jetty.version` 12.1.12 → 12.1.13
- `AbstractJettyTestSupport.JETTY_VERSION` updated so the integration tests provision the matching Jetty artifacts
- CHANGELOG entry added

The Jetty 11 bundle (`http/jetty`, 11.0.26) is untouched.

Unit tests pass for `http/base` and `http/jetty12` (`mvn -pl base,jetty12 -am test`, 0 failures / 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
